### PR TITLE
Add support for the `images={}` attribute.

### DIFF
--- a/examples/hello-grpc/cc/server/BUILD
+++ b/examples/hello-grpc/cc/server/BUILD
@@ -23,12 +23,12 @@ cc_image(
     deps = ["//examples/hello-grpc/proto"],
 )
 
-load("@io_bazel_rules_docker//docker:docker.bzl", "docker_push")
+load("@k8s_deploy//:defaults.bzl", "k8s_deploy")
 
-docker_push(
-    name = "push",
-    image = ":server",
-    registry = "us.gcr.io",
-    repository = "rules_k8s/examples/hello-grpc",
-    tag = "cc",
+k8s_deploy(
+    name = "staging",
+    images = {
+        "us.gcr.io/rules_k8s/hello-grpc:staging": ":server",
+    },
+    template = "//examples/hello-grpc:deployment.yaml",
 )

--- a/k8s/object.bzl
+++ b/k8s/object.bzl
@@ -47,7 +47,6 @@ def _impl(ctx):
     # Each images entry results in a single --image_spec argument.
     # As part of this walk, we also collect all of the image's input files
     # to include as runfiles, so they are accessible to be pushed.
-    index = 0
     for tag in ctx.attr.images:
       target = ctx.attr.images[tag]
       image = _get_layers(ctx, image_target_dict[target], image_files_dict[target])
@@ -72,7 +71,6 @@ def _impl(ctx):
         "%s=%s" % (k, v)
         for (k, v) in image_spec.items()
       ])]
-      index += 1
 
   ctx.action(
       command = """cat > {resolve_script} <<"EOF"

--- a/k8s/object.bzl
+++ b/k8s/object.bzl
@@ -13,6 +13,16 @@
 # limitations under the License.
 """An implementation of k8s_object for interacting with an object of kind."""
 
+load(
+    "@io_bazel_rules_docker//docker:layers.bzl",
+    _get_layers = "get_from_target",
+    _layer_tools = "tools",
+)
+load(
+    "@io_bazel_rules_docker//docker:label.bzl",
+    _string_to_label = "string_to_label",
+)
+
 def _impl(ctx):
   """Core implementation of k8s_object."""
 
@@ -23,13 +33,59 @@ def _impl(ctx):
       substitutions = {},
   )
 
+  all_inputs = []
+  image_specs = []
+  if ctx.attr.images:
+    # Compute the set of layers from the image_targets.
+    image_target_dict = _string_to_label(
+        ctx.attr.image_targets, ctx.attr.image_target_strings)
+    image_files_dict = _string_to_label(
+        ctx.files.image_targets, ctx.attr.image_target_strings)
+
+    # Walk the collection of images passed and for each key/value pair
+    # collect the parts to pass to the resolver as --image_spec arguments.
+    # Each images entry results in a single --image_spec argument.
+    # As part of this walk, we also collect all of the image's input files
+    # to include as runfiles, so they are accessible to be pushed.
+    index = 0
+    for tag in ctx.attr.images:
+      target = ctx.attr.images[tag]
+      image = _get_layers(ctx, image_target_dict[target], image_files_dict[target])
+
+      image_spec = {"name": tag}
+      if image.get("legacy"):
+        image_spec["tarball"] = image["legacy"]
+        all_inputs += [image["legacy"]]
+
+      blobsums = image.get("blobsum", [])
+      image_spec["digest"] = ",".join([f.short_path for f in blobsums])
+      all_inputs += blobsums
+
+      blobs = image.get("zipped_layer", [])
+      image_spec["layer"] = ",".join([f.short_path for f in blobs])
+      all_inputs += blobs
+
+      image_spec["config"] = image["config"].short_path
+      all_inputs += [image["config"]]
+
+      image_specs += [";".join([
+        "%s=%s" % (k, v)
+        for (k, v) in image_spec.items()
+      ])]
+      index += 1
+
   ctx.action(
       command = """cat > {resolve_script} <<"EOF"
 #!/bin/bash -e
-{resolver} --template {yaml}
+{resolver} --template {yaml} {images}
 EOF""".format(
         resolver = ctx.executable._resolver.short_path,
         yaml = ctx.outputs.yaml.short_path,
+        images = " ".join([
+          # Quote the parameter otherwise semi-colons complete the command.
+          "--image_spec='%s'" % spec
+          for spec in image_specs
+        ]),
         resolve_script = ctx.outputs.executable.path,
       ),
       inputs = [],
@@ -37,11 +93,10 @@ EOF""".format(
       mnemonic = "ResolveScript"
   )
 
-
   return struct(runfiles = ctx.runfiles(files = [
     ctx.executable._resolver,
     ctx.outputs.yaml,
-  ]))
+  ] + all_inputs))
 
 _common_attrs = {
     # TODO(mattmoor): Add cluster / namespace once we have executable friends.
@@ -64,7 +119,10 @@ _k8s_object = rule(
             single_file = True,
             mandatory = True,
         ),
-        # TODO(mattmoor): images
+        "images": attr.string_dict(),
+        # Implicit dependencies.
+        "image_targets": attr.label_list(allow_files = True),
+        "image_target_strings": attr.string_list(),
     } + _common_attrs,
     executable = True,
     outputs = {
@@ -81,6 +139,13 @@ def k8s_object(name, **kwargs):
     namespace: the namespace within the cluster.
     kind: the object kind.
     template: the yaml template to instantiate.
+    images: a dictionary from fully-qualified tag to label.
   """
+  for reserved in ["image_targets", "image_target_strings", "resolved"]:
+    if reserved in kwargs:
+      fail("reserved for internal use by docker_bundle macro", attr=reserved)
+
+  kwargs["image_targets"] = list(set(kwargs.get("images", {}).values()))
+  kwargs["image_target_strings"] = list(set(kwargs.get("images", {}).values()))
 
   _k8s_object(name=name, **kwargs)


### PR DESCRIPTION
When the `images={}` attribute is specified resolution will publish the collection of images, and substitute the exact digest of the published image as part of resolution (avoids race condition).