### PR TITLE
Remove deprecated set constructor

### DIFF
--- a/k8s/object.bzl
+++ b/k8s/object.bzl
@@ -23,6 +23,13 @@ load(
     _string_to_label = "string_to_label",
 )
 
+def _deduplicate(iterable):
+  """
+  Performs a deduplication (similar to `list(set(...))`,
+  but `set` is not available in Skylark).
+  """
+  return {k: None for k in iterable}.keys()
+
 def _impl(ctx):
   """Core implementation of k8s_object."""
 
@@ -238,8 +245,8 @@ def k8s_object(name, **kwargs):
     if reserved in kwargs:
       fail("reserved for internal use by docker_bundle macro", attr=reserved)
 
-  kwargs["image_targets"] = list(set(kwargs.get("images", {}).values()))
-  kwargs["image_target_strings"] = list(set(kwargs.get("images", {}).values()))
+  kwargs["image_targets"] = _deduplicate(kwargs.get("images", {}).values())
+  kwargs["image_target_strings"] = _deduplicate(kwargs.get("images", {}).values())
 
   _k8s_object(name=name, **kwargs)
 


### PR DESCRIPTION
The `set` constructor in Skylark is deprecated and will be removed soon in favor of `depset` Furthermore, depsets will become non-iterable in the future, the recommended way for deduplicating lists is by using dicts: `{k: None for k in iterable}.keys()`. 