### PR TITLE
Stop using .short_path to reference stuff in actions.

### DIFF
--- a/examples/hellogrpc/e2e-test.sh
+++ b/examples/hellogrpc/e2e-test.sh
@@ -22,7 +22,8 @@ function get_lb_ip() {
 }
 
 function create() {
-   bazel run examples/hellogrpc/${LANGUAGE}/server:staging.create
+   bazel build examples/hellogrpc/${LANGUAGE}/server:staging.create
+   bazel-bin/examples/hellogrpc/${LANGUAGE}/server/staging.create
 }
 
 function check_msg() {
@@ -38,12 +39,15 @@ function edit() {
 }
 
 function update() {
-   bazel run examples/hellogrpc/${LANGUAGE}/server:staging.replace
+   bazel build examples/hellogrpc/${LANGUAGE}/server:staging.replace
+   bazel-bin/examples/hellogrpc/${LANGUAGE}/server/staging.replace
 }
 
 function delete() {
-   bazel run examples/hellogrpc/${LANGUAGE}/server:staging.describe
-   bazel run examples/hellogrpc/${LANGUAGE}/server:staging.delete
+   bazel build examples/hellogrpc/${LANGUAGE}/server:staging.describe
+   bazel-bin/examples/hellogrpc/${LANGUAGE}/server/staging.describe
+   bazel build examples/hellogrpc/${LANGUAGE}/server:staging.delete
+   bazel-bin/examples/hellogrpc/${LANGUAGE}/server/staging.delete
 }
 
 

--- a/k8s/BUILD
+++ b/k8s/BUILD
@@ -18,6 +18,7 @@ licenses(["notice"])  # Apache 2.0
 exports_files([
     "create.sh.tpl",
     "replace.sh.tpl",
+    "resolve.sh.tpl",
     "delete.sh.tpl",
     "describe.sh.tpl",
 ])

--- a/k8s/create.sh.tpl
+++ b/k8s/create.sh.tpl
@@ -15,7 +15,15 @@
 # limitations under the License.
 set -euo pipefail
 
+function guess_runfiles() {
+    pushd ${BASH_SOURCE[0]}.runfiles > /dev/null 2>&1
+    pwd
+    popd > /dev/null 2>&1
+}
+
+RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
+
 # TODO(mattmoor): Should we create namespaces that do not exist?
 
-./%{resolve_script} | \
+PYTHON_RUNFILES=${RUNFILES} %{resolve_script} | \
   kubectl --cluster="%{cluster}" --namespace="%{namespace}" create -f -

--- a/k8s/delete.sh.tpl
+++ b/k8s/delete.sh.tpl
@@ -15,5 +15,13 @@
 # limitations under the License.
 set -euo pipefail
 
+function guess_runfiles() {
+    pushd ${BASH_SOURCE[0]}.runfiles > /dev/null 2>&1
+    pwd
+    popd > /dev/null 2>&1
+}
+
+RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
+
 kubectl --cluster="%{cluster}" --namespace="%{namespace}" delete \
     -f %{unresolved}

--- a/k8s/describe.sh.tpl
+++ b/k8s/describe.sh.tpl
@@ -15,6 +15,14 @@
 # limitations under the License.
 set -euo pipefail
 
+function guess_runfiles() {
+    pushd ${BASH_SOURCE[0]}.runfiles > /dev/null 2>&1
+    pwd
+    popd > /dev/null 2>&1
+}
+
+RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
+
 RESOURCE_NAME=$(kubectl create --dry-run -f "%{unresolved}" | cut -d'"' -f 2)
 
 kubectl --cluster="%{cluster}" --namespace="%{namespace}" \

--- a/k8s/resolve.sh.tpl
+++ b/k8s/resolve.sh.tpl
@@ -23,5 +23,4 @@ function guess_runfiles() {
 
 RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
 
-PYTHON_RUNFILES=${RUNFILES} %{resolve_script} | \
-  kubectl --cluster="%{cluster}" --namespace="%{namespace}" replace -f -
+%{resolver} --template %{yaml} %{images}


### PR DESCRIPTION
This hinders two things:
1. Separate `bazel build` and running via `bazel-bin/...` (vs. `bazel run`)
1. Embedding these scripts into other actions.

This also changes the tool references from `.par` to the `py_binary` directly as this should improve portability to Windows.

Fixes: https://github.com/bazelbuild/rules_k8s/issues/26