### PR TITLE
Bugfix: Extracts short_path from tarball-File

### DIFF
--- a/k8s/object.bzl
+++ b/k8s/object.bzl
@@ -60,7 +60,7 @@ def _impl(ctx):
 
       image_spec = {"name": tag}
       if image.get("legacy"):
-        image_spec["tarball"] = image["legacy"]
+        image_spec["tarball"] = image["legacy"].short_path
         all_inputs += [image["legacy"]]
 
       blobsums = image.get("blobsum", [])


### PR DESCRIPTION
This removes the bug not allowing k8s_object() to work on images from docker_build() targets with a legacy layer.

I saw your pending change to move from .short_path and this will need updating as well.

And good job with rules_k8s! :)
//David, from Cinnober