### PR TITLE
This change adds preliminary support for k8s_objects.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -37,6 +37,13 @@ k8s_defaults(
     namespace = "{BUILD_USER}",
 )
 
+k8s_defaults(
+    name = "k8s_service",
+    cluster = "gke_rules-k8s_us-central1-f_testing",
+    kind = "service",
+    namespace = "{BUILD_USER}",
+)
+
 new_http_archive(
     name = "mock",
     build_file_content = """

--- a/examples/hellogrpc/BUILD
+++ b/examples/hellogrpc/BUILD
@@ -18,8 +18,25 @@ licenses(["notice"])  # Apache 2.0
 load("@k8s_deploy//:defaults.bzl", "k8s_deploy")
 
 k8s_deploy(
-    name = "staging",
+    name = "staging-deployment",
     template = "deployment.yaml",
+)
+
+load("@k8s_service//:defaults.bzl", "k8s_service")
+
+k8s_deploy(
+    name = "staging-service",
+    template = "service.yaml",
+)
+
+load("@io_bazel_rules_k8s//k8s:objects.bzl", "k8s_objects")
+
+k8s_objects(
+    name = "staging",
+    objects = [
+        ":staging-deployment",
+        ":staging-service",
+    ],
 )
 
 load("@io_bazel_rules_jsonnet//jsonnet:jsonnet.bzl", "jsonnet_to_json")

--- a/examples/hellogrpc/service.yaml
+++ b/examples/hellogrpc/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: hello-grpc-staging
+  name: hello-grpc-staging
+spec:
+  ports:
+  - port: 50051
+    protocol: TCP
+    targetPort: 50051
+  selector:
+    app: hello-grpc-staging
+  type: LoadBalancer

--- a/k8s/BUILD
+++ b/k8s/BUILD
@@ -20,6 +20,7 @@ exports_files([
     "create.sh.tpl",
     "replace.sh.tpl",
     "resolve.sh.tpl",
+    "resolve-all.sh.tpl",
     "delete.sh.tpl",
     "describe.sh.tpl",
 ])

--- a/k8s/objects.bzl
+++ b/k8s/objects.bzl
@@ -1,0 +1,73 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""An implementation of k8s_object for interacting with an object of kind."""
+
+load(
+    "@io_bazel_rules_docker//skylib:path.bzl",
+    _get_runfile_path = "runfile",
+)
+
+def _runfiles(ctx, f):
+  return "PYTHON_RUNFILES=${RUNFILES} ${RUNFILES}/%s" % _get_runfile_path(ctx, f)
+
+def _run_all_impl(ctx):
+  ctx.actions.expand_template(
+      template = ctx.file._template,
+      substitutions = {
+          "%{resolve_statements}": ("\n" + ctx.attr.delimiter).join([
+              _runfiles(ctx, exe.files_to_run.executable)
+              for exe in ctx.attr.objects
+          ]),
+      },
+      output = ctx.outputs.executable,
+  )
+
+  runfiles = [obj.files_to_run.executable for obj in ctx.attr.objects]
+  for obj in ctx.attr.objects:
+    runfiles += list(obj.default_runfiles.files)
+
+  return struct(runfiles = ctx.runfiles(files = runfiles))
+
+_run_all = rule(
+    attrs = {
+        "objects": attr.label_list(
+            cfg = "host",
+        ),
+        "_template": attr.label(
+            default = Label("//k8s:resolve-all.sh.tpl"),
+            single_file = True,
+            allow_files = True,
+        ),
+        "delimiter": attr.string(default = ""),
+    },
+    executable = True,
+    implementation = _run_all_impl,
+)
+
+def k8s_objects(name, objects):
+  """Interact with a collection of K8s objects.
+
+  Args:
+    name: name of the rule.
+    objects: list of k8s_object rules.
+  """
+
+  # TODO(mattmoor): We may have to normalize the labels that come
+  # in through objects.
+
+  _run_all(name=name, objects=objects, delimiter="echo ---\n")
+  _run_all(name=name + ".create", objects=[x + ".create" for x in objects])
+  _run_all(name=name + ".delete", objects=[x + ".delete" for x in objects])
+  _run_all(name=name + ".replace", objects=[x + ".replace" for x in objects])
+  _run_all(name=name + ".apply", objects=[x + ".apply" for x in objects])

--- a/k8s/resolve-all.sh.tpl
+++ b/k8s/resolve-all.sh.tpl
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -euo pipefail
+
+function guess_runfiles() {
+    pushd ${BASH_SOURCE[0]}.runfiles > /dev/null 2>&1
+    pwd
+    popd > /dev/null 2>&1
+}
+
+RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
+
+%{resolve_statements}


### PR DESCRIPTION
`k8s_objects` takes a list of K8s objects across which to take certain actions.

`k8s_objects` also supports nesting, so a `k8s_objects` can take another `k8s_objects`.

Fixes: https://github.com/bazelbuild/rules_k8s/issues/46