### PR TITLE
Allow k8s_object to chroot image references

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -33,6 +33,7 @@ k8s_repositories()
 k8s_defaults(
     name = "k8s_deploy",
     cluster = "gke_rules-k8s_us-central1-f_testing",
+    image_chroot = "us.gcr.io/rules_k8s/{BUILD_USER}",
     kind = "deployment",
     namespace = "{BUILD_USER}",
 )

--- a/examples/hellogrpc/cc/server/BUILD
+++ b/examples/hellogrpc/cc/server/BUILD
@@ -28,7 +28,7 @@ load("@k8s_deploy//:defaults.bzl", "k8s_deploy")
 k8s_deploy(
     name = "staging",
     images = {
-        "us.gcr.io/rules_k8s/hello-grpc:staging": ":server",
+        "us.gcr.io/not-my-project/hello-grpc:staging": ":server",
     },
     template = "//examples/hellogrpc:deployment.yaml",
 )

--- a/examples/hellogrpc/deployment.jsonnet
+++ b/examples/hellogrpc/deployment.jsonnet
@@ -17,5 +17,5 @@ local container = import "../container.libsonnet";
 deployment.Simple("hello-grpc-staging",
 	          container.Simple(
 		     "hello-grpc",
-		     "us.gcr.io/rules_k8s/hello-grpc:staging",
+		     "us.gcr.io/not-my-project/hello-grpc:staging",
 		     50051))

--- a/examples/hellogrpc/deployment.yaml
+++ b/examples/hellogrpc/deployment.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
       - name: hello-grpc
-        image: us.gcr.io/rules_k8s/hello-grpc:staging
+        image: us.gcr.io/not-my-project/hello-grpc:staging
         imagePullPolicy: Always
         ports:
         - containerPort: 50051

--- a/examples/hellogrpc/go/server/BUILD
+++ b/examples/hellogrpc/go/server/BUILD
@@ -19,7 +19,7 @@ load("@org_pubref_rules_protobuf//go:rules.bzl", "GRPC_COMPILE_DEPS")
 go_image(
     name = "server",
     srcs = ["main.go"],
-    importpath = "github.com/bazelbuild/rules_k8s/rules_k8s/examples/hellogrpc/go/server",
+    importpath = "github.com/bazelbuild/not-my-project/examples/hellogrpc/go/server",
     deps = [
         "//examples/hellogrpc/proto:go",
     ] + GRPC_COMPILE_DEPS,
@@ -30,7 +30,7 @@ load("@k8s_deploy//:defaults.bzl", "k8s_deploy")
 k8s_deploy(
     name = "staging",
     images = {
-        "us.gcr.io/rules_k8s/hello-grpc:staging": ":server",
+        "us.gcr.io/not-my-project/hello-grpc:staging": ":server",
     },
     template = "//examples/hellogrpc:deployment.json",
 )

--- a/examples/hellogrpc/java/server/BUILD
+++ b/examples/hellogrpc/java/server/BUILD
@@ -33,7 +33,7 @@ load("@k8s_deploy//:defaults.bzl", "k8s_deploy")
 k8s_deploy(
     name = "staging",
     images = {
-        "us.gcr.io/rules_k8s/hello-grpc:staging": ":server",
+        "us.gcr.io/not-my-project/hello-grpc:staging": ":server",
     },
     template = "//examples/hellogrpc:deployment.json",
 )

--- a/examples/hellogrpc/py/server/BUILD
+++ b/examples/hellogrpc/py/server/BUILD
@@ -38,7 +38,7 @@ load("@k8s_deploy//:defaults.bzl", "k8s_deploy")
 k8s_deploy(
     name = "staging",
     images = {
-        "us.gcr.io/rules_k8s/hello-grpc:staging": ":server",
+        "us.gcr.io/not-my-project/hello-grpc:staging": ":server",
     },
     template = "//examples/hellogrpc:deployment.yaml",
 )

--- a/examples/hellohttp/deployment.jsonnet
+++ b/examples/hellohttp/deployment.jsonnet
@@ -17,5 +17,5 @@ local container = import "../container.libsonnet";
 deployment.Simple("hello-http-staging",
 	          container.Simple(
 		     "hello-http",
-		     "us.gcr.io/rules_k8s/hello-http:staging",
+		     "us.gcr.io/not-my-project/hello-http:staging",
 		     8080))

--- a/examples/hellohttp/deployment.yaml
+++ b/examples/hellohttp/deployment.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
       - name: hello-http
-        image: us.gcr.io/rules_k8s/hello-http:staging
+        image: us.gcr.io/not-my-project/hello-http:staging
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/examples/hellohttp/go/BUILD
+++ b/examples/hellohttp/go/BUILD
@@ -5,7 +5,7 @@ load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 go_image(
     name = "server",
     srcs = ["main.go"],
-    importpath = "github.com/bazelbuild/rules_k8s/rules_k8s/examples/hellohttp/go",
+    importpath = "github.com/bazelbuild/not-my-project/examples/hellohttp/go",
 )
 
 load("@k8s_deploy//:defaults.bzl", "k8s_deploy")
@@ -13,7 +13,7 @@ load("@k8s_deploy//:defaults.bzl", "k8s_deploy")
 k8s_deploy(
     name = "staging",
     images = {
-        "us.gcr.io/rules_k8s/hello-http:staging": ":server",
+        "us.gcr.io/not-my-project/hello-http:staging": ":server",
     },
     template = "//examples/hellohttp:deployment.yaml",
 )

--- a/examples/hellohttp/java/BUILD
+++ b/examples/hellohttp/java/BUILD
@@ -30,7 +30,7 @@ load("@k8s_deploy//:defaults.bzl", "k8s_deploy")
 k8s_deploy(
     name = "staging",
     images = {
-        "us.gcr.io/rules_k8s/hello-http:staging": ":server",
+        "us.gcr.io/not-my-project/hello-http:staging": ":server",
     },
     template = "//examples/hellohttp:deployment.json",
 )

--- a/k8s/resolve.sh.tpl
+++ b/k8s/resolve.sh.tpl
@@ -23,4 +23,4 @@ function guess_runfiles() {
 
 RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
 
-%{resolver} --template %{yaml} %{images}
+%{resolver} --template %{yaml} --image_chroot=%{image_chroot} %{images}

--- a/k8s/resolver_test.py
+++ b/k8s/resolver_test.py
@@ -101,7 +101,7 @@ key1:
 
     with mock.patch.object(v2_2_session, 'Push', return_value=NopPush()):
       (tag, digest) = resolver.Publish(
-          _BAD_TRANSPORT, name=str(name), tarball=td)
+          _BAD_TRANSPORT, None, name=str(name), tarball=td)
       self.assertEqual(tag, name)
       with v2_2_image.FromTarball(td) as img:
         self.assertEqual(digest.digest, img.digest())
@@ -117,7 +117,7 @@ key1:
 
     with mock.patch.object(v2_2_session, 'Push', return_value=NopPush()):
       (tag, digest) = resolver.Publish(
-          _BAD_TRANSPORT, name=str(name), config=config_path,
+          _BAD_TRANSPORT, None, name=str(name), config=config_path,
           digest=','.join([h for (h, unused) in layer_data]),
           layer=','.join([layer for (unused, layer) in layer_data]))
       self.assertEqual(tag, name)

--- a/k8s/with-defaults.bzl
+++ b/k8s/with-defaults.bzl
@@ -65,6 +65,10 @@ def _impl(repository_ctx):
     overrides += [_override(repository_ctx.attr.name,
                             "kind", repository_ctx.attr.kind)]
 
+  if repository_ctx.attr.image_chroot:
+    overrides += [_override(repository_ctx.attr.name,
+                            "image_chroot", repository_ctx.attr.image_chroot)]
+
   repository_ctx.file("defaults.bzl", """
 load(
   "@io_bazel_rules_k8s//k8s:object.bzl",
@@ -83,6 +87,7 @@ k8s_defaults = repository_rule(
         "kind": attr.string(mandatory = False),
         "cluster": attr.string(mandatory = False),
         "namespace": attr.string(mandatory = False),
+        "image_chroot": attr.string(mandatory = False),
     },
     implementation = _impl,
 )


### PR DESCRIPTION
Fixes: https://github.com/bazelbuild/rules_k8s/issues/47