### PR TITLE
Add a simple Kubernetes custom controller/resource example.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,3 +56,5 @@ script:
   - ./examples/hellohttp/e2e-test.sh java
   - ./examples/hellohttp/e2e-test.sh go
   - ./examples/hellohttp/e2e-test.sh py
+  # Third, TODO Controller.
+  - ./examples/todocontroller/e2e-test.sh py

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -30,20 +30,28 @@ load("//k8s:k8s.bzl", "k8s_repositories", "k8s_defaults")
 
 k8s_repositories()
 
-k8s_defaults(
-    name = "k8s_deploy",
-    cluster = "gke_rules-k8s_us-central1-f_testing",
-    image_chroot = "us.gcr.io/rules_k8s/{BUILD_USER}",
-    kind = "deployment",
-    namespace = "{BUILD_USER}",
-)
+_CLUSTER = "gke_rules-k8s_us-central1-f_testing"
+
+_NAMESPACE = "{BUILD_USER}"
 
 k8s_defaults(
-    name = "k8s_service",
-    cluster = "gke_rules-k8s_us-central1-f_testing",
-    kind = "service",
-    namespace = "{BUILD_USER}",
+    name = "k8s_deploy",
+    cluster = _CLUSTER,
+    image_chroot = "us.gcr.io/rules_k8s/{BUILD_USER}",
+    kind = "deployment",
+    namespace = _NAMESPACE,
 )
+
+[k8s_defaults(
+    name = "k8s_" + kind,
+    cluster = _CLUSTER,
+    kind = kind,
+    namespace = _NAMESPACE,
+) for kind in [
+    "service",
+    "crd",
+    "todo",
+]]
 
 new_http_archive(
     name = "mock",
@@ -131,7 +139,7 @@ go_proto_repositories()
 
 git_repository(
     name = "io_bazel_rules_python",
-    commit = "d6fbb0fb2a5c8e318dd4de5104dc41358cefaa90",
+    commit = "c208292d1286e9a0280555187caf66cd3b4f5bed",
     remote = "https://github.com/bazelbuild/rules_python.git",
 )
 
@@ -188,3 +196,15 @@ git_repository(
 load("@io_bazel_rules_jsonnet//jsonnet:jsonnet.bzl", "jsonnet_repositories")
 
 jsonnet_repositories()
+
+pip_import(
+    name = "examples_todocontroller_pip",
+    requirements = "//examples/todocontroller/py:requirements.txt",
+)
+
+load(
+    "@examples_todocontroller_pip//:requirements.bzl",
+    _controller_pip_install = "pip_install",
+)
+
+_controller_pip_install()

--- a/examples/todocontroller/BUILD
+++ b/examples/todocontroller/BUILD
@@ -1,0 +1,32 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # Apache 2.0
+
+exports_files(["deployment.yaml"])
+
+load("@k8s_crd//:defaults.bzl", "k8s_crd")
+
+k8s_crd(
+    name = "todo-crd",
+    template = ":todo.yaml",
+)
+
+load("@k8s_todo//:defaults.bzl", "k8s_todo")
+
+k8s_todo(
+    name = "example-todo",
+    template = ":example.yaml",
+)

--- a/examples/todocontroller/deployment.yaml
+++ b/examples/todocontroller/deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: todo-controller-staging
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: todo-controller-staging
+    spec:
+      containers:
+      - name: todo-controller
+        image: us.gcr.io/not-my-project/todo-controller:staging
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 50051
+        env:
+          - name: MY_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace

--- a/examples/todocontroller/example.yaml
+++ b/examples/todocontroller/example.yaml
@@ -1,0 +1,7 @@
+apiVersion: "rules-k8s.bazel.io/v1"
+kind: Todo
+metadata:
+  name: my-todo
+spec:
+  subject: Do something
+  done: false

--- a/examples/todocontroller/py/BUILD
+++ b/examples/todocontroller/py/BUILD
@@ -1,0 +1,48 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # Apache 2.0
+
+load("@examples_todocontroller_pip//:requirements.bzl", "requirement")
+load("@io_bazel_rules_docker//python:image.bzl", "py_image")
+
+py_image(
+    name = "controller",
+    srcs = ["controller.py"],
+    main = "controller.py",
+    deps = [
+        requirement("kubernetes"),
+    ],
+)
+
+load("@k8s_deploy//:defaults.bzl", "k8s_deploy")
+
+k8s_deploy(
+    name = "controller-deployment",
+    images = {
+        "us.gcr.io/not-my-project/todo-controller:staging": ":controller",
+    },
+    template = "//examples/todocontroller:deployment.yaml",
+)
+
+load("@io_bazel_rules_k8s//k8s:objects.bzl", "k8s_objects")
+
+k8s_objects(
+    name = "staging",
+    objects = [
+        "//examples/todocontroller:todo-crd",
+        ":controller-deployment",
+    ],
+)

--- a/examples/todocontroller/py/controller.py
+++ b/examples/todocontroller/py/controller.py
@@ -1,0 +1,59 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from kubernetes import client, config, watch
+import logging
+import os
+
+DOMAIN = "rules-k8s.bazel.io"
+
+def main():
+    config.load_incluster_config()
+
+    # Exposed to us through the downward API.
+    namespace = os.environ["MY_NAMESPACE"]
+
+    crds = client.CustomObjectsApi()
+
+    def mark_done(event, obj):
+        metadata = obj.get("metadata")
+        if not metadata:
+            logging.error("No metadata in object, skipping: %s", json.dumps(obj, indent=1))
+            return
+        name = metadata.get("name")
+
+        obj["spec"]["done"] = True
+        obj["spec"]["comment"] = "DEMO "
+
+        logging.error("Updating: %s", name)
+        crds.replace_namespaced_custom_object(DOMAIN, "v1", namespace, "todos", name, obj)
+
+    # TODO(mattmoor): Integration test that deploys this, creates TODOs,
+    # and then checks for the appropriate $RANDOM string.
+    stream = watch.Watch().stream(crds.list_namespaced_custom_object, DOMAIN, "v1", namespace, "todos")
+    for event in stream:
+        obj = event["object"]
+        spec = obj.get("spec")
+        if not spec:
+            logging.error("No 'spec' in object, skipping event: %s", json.dumps(obj, indent=1))
+            continue
+        done = spec.get("done", True)
+        if done:
+            continue
+        mark_done(event, obj)
+        
+
+if __name__ == "__main__":
+    main()

--- a/examples/todocontroller/py/edit.sh
+++ b/examples/todocontroller/py/edit.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -e
+
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SUFFIX="$1"
+
+sed -i "s/DEMO *[a-z0-9_-]* */DEMO${SUFFIX} /g" ./examples/todocontroller/py/controller.py

--- a/examples/todocontroller/py/requirements.txt
+++ b/examples/todocontroller/py/requirements.txt
@@ -1,0 +1,1 @@
+kubernetes==3.0.0

--- a/examples/todocontroller/todo.yaml
+++ b/examples/todocontroller/todo.yaml
@@ -1,0 +1,22 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: todos.rules-k8s.bazel.io
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: rules-k8s.bazel.io
+  # version name to use for REST API: /apis/<group>/<version>
+  version: v1
+  # either Namespaced or Cluster
+  scope: Namespaced
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: todos
+    # singular name to be used as an alias on the CLI and for display
+    singular: todo
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: Todo
+    # # shortNames allow shorter string to match your resource on the CLI
+    # shortNames:
+    # - todo


### PR DESCRIPTION
This has a handful of components:
 - a "TODO" Custom Resource Definition (CRD),
 - a "TODO" example instance, and
 - a Custom Controller that watches for "TODOs" not marked "done" and completes them with a comment.

This also adds a little e2e test that:
 - Creates the CRD/Controller and starter TODO
 - Checks the note on the TODO
 - Updates the Controller (waits) and then the TODO (waits)
 - Checks the note on the TODO has changed appropriately
 - Repeat edit/check
 - Teardown

Fixes: https://github.com/bazelbuild/rules_k8s/issues/30