### PR TITLE
Update rules_protobuf

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -72,7 +72,7 @@ py_library(
 
 git_repository(
     name = "org_pubref_rules_protobuf",
-    commit = "d9523f3d443b6a4f3fabc72051d84eb5474d7745",  # v0.8.1 (Sep 23 2017)
+    commit = "4cc90ab2b9f4d829b9706221d4167bc7fb3bd247",  # patched v0.8.1 (Sep 27 2017)
     remote = "https://github.com/pubref/rules_protobuf.git",
 )
 


### PR DESCRIPTION
Starting from Bazel 0.8 the += operator applied to lists will mutate them instead of copying. This is an incompatible behavior and repostories should be fixed in advance.

To reproduce the future behavior one can use the following flag:

    bazel build --incompatible_list_plus_equals_inplace //...

This PR updates rules_protobuf so that the following commit is also included: https://github.com/pubref/rules_protobuf/commit/4cc90ab2b9f4d829b9706221d4167bc7fb3bd247