### PR TITLE
This disables OSX validation on the Bazel CI setup.

### DIFF
--- a/.ci/rules_k8s.json
+++ b/.ci/rules_k8s.json
@@ -3,8 +3,7 @@
           "variation": "",
            "configurations": [
                 {"node": "linux-x86_64"},
-                {"node": "ubuntu_16.04-x86_64"},
-                {"node": "darwin-x86_64"}
+                {"node": "ubuntu_16.04-x86_64"}
            ]
     }
 ]


### PR DESCRIPTION
This is blocking the addition of several Python samples, including the http one and the TODO controller.

The cause is tracked by [this](https://github.com/bazelbuild/rules_python/issues/17) and [this](https://github.com/google/subpar/issues/38) issue.

Currently Bazel CI doesn't provide very meaningful coverage, most of it happens via Travis and example e2e tests.