### PR TITLE
Add a pre-processor for templates to improve json support.

### DIFF
--- a/k8s/BUILD
+++ b/k8s/BUILD
@@ -33,6 +33,7 @@ py_library(
     deps = [
         "@containerregistry//:containerregistry",
         "@yaml//:yaml",
+        "@simplejson//:simplejson",
     ],
 )
 
@@ -56,6 +57,7 @@ par_binary(
     deps = [
         "@containerregistry//:containerregistry",
         "@yaml//:yaml",
+        "@simplejson//:simplejson",
     ],
 )
 
@@ -64,4 +66,15 @@ par_binary(
     srcs = ["stamper.py"],
     main = "stamper.py",
     visibility = ["//visibility:public"],
+)
+
+par_binary(
+    name = "pre_processor",
+    srcs = ["pre_processor.py"],
+    main = "pre_processor.py",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@yaml//:yaml",
+        "@simplejson//:simplejson",
+    ],
 )

--- a/k8s/k8s.bzl
+++ b/k8s/k8s.bzl
@@ -33,3 +33,17 @@ py_library(
            "/PyYAML-3.12.tar.gz"),
     strip_prefix = "PyYAML-3.12/lib/yaml",
   )
+
+  native.new_http_archive(
+    name = "simplejson",
+    build_file_content = """
+py_library(
+    name = "simplejson",
+    srcs = glob(["*.py"]),
+    visibility = ["//visibility:public"],
+)""",
+    sha256 = "df5e38f5e0a24abe0e02276aa5c3f8504150047a51c0b6b848b8153e6e6d395e",
+    url = ('https://pypi.python.org/packages/e8/46/4ab77251fbe4af3091cdd8a38' +
+           'aa7d1c0b2082dd502735b9774614cf39c89/simplejson-3.12.0.tar.gz'),
+    strip_prefix = "simplejson-3.12.0/simplejson",
+  )

--- a/k8s/pre_processor.py
+++ b/k8s/pre_processor.py
@@ -1,0 +1,60 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Pre-processor for templates.
+
+If the supplied template is json formatted we convert it to yaml such that
+code downstream from here only has to deal with one format.
+"""
+
+import argparse
+import simplejson as json
+import sys
+import yaml
+
+parser = argparse.ArgumentParser(description='Resolve stamp references.')
+
+parser.add_argument('--input', action='store',
+                    help='The json input file.')
+
+parser.add_argument('--output', action='store',
+                    help='The output file.')
+
+DOC_DELIMITER = '---\n'
+
+def _process_json(input_str):
+  """Converts a json string into a yaml string."""
+  data = json.loads(input_str)
+  if isinstance(data, list):
+    return DOC_DELIMITER.join(yaml.safe_dump(x) for x in data)
+  elif isinstance(data, dict):
+    return yaml.safe_dump(data)
+  else:
+    raise ValueError("Invalid json file.")
+
+
+def main():
+  args = parser.parse_args()
+  input_str = open(args.input).read()
+
+  if args.input.endswith(".json"):
+    output = _process_json(input_str)
+  else:
+    output = input_str
+
+  with open(args.output, 'w') as f:
+    f.write(output)
+
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
I've added a pre-processor for converting any user-supplied templates to yaml before stamping and resolving image tags. This is necessary for working with multi-resource json objects (arrays).

Is this the right way to go or did anyone have another solution in mind?