### PR TITLE
Make resolver a public property

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,37 @@ Then the references to `gcr.io/rules_k8s/server:dev` will be replaced with one
 to: `us.gcr.io/company-{BUILD_USER}/dev/gcr.io/rules_k8s/server@sha256:...`.
 
 
+### Custom resolvers
+
+Sometimes, you need to replace additional runtime parameters in the YAML file.
+While you can use `expand_template` for parameters known to the build system,
+you'll need a custom resolver if the parameter is determined at deploy time.
+A common example is Google Cloud Endpoints service versions, which are
+determined by the server.
+
+You can pass a custom resolver executable as the `resolver` argument of all
+rules:
+
+```python
+sh_binary(
+  name = "my_script",
+  ...
+)
+
+k8s_deploy(
+  name = "dev"
+  template = ":deployment.yaml",
+  images = {
+    "gcr.io/rules_k8s/server:dev": "//server:image"
+  },
+  resolver = "//my_script",
+)
+```
+
+This script needs to invoke the default resolver (`//k8s:resolver`) with all its
+arguments, but may capture the output and apply additional modifications.
+
+
 ## Usage
 
 The `k8s_object[s]` rules expose a collection of actions.  We will follow the `:dev`

--- a/README.md
+++ b/README.md
@@ -291,8 +291,9 @@ k8s_deploy(
 )
 ```
 
-This script needs to invoke the default resolver (`//k8s:resolver`) with all its
-arguments, but may capture the output and apply additional modifications.
+This script may need to invoke the default resolver (`//k8s:resolver`) with all
+its arguments. It may capture the default resolver's output and apply additional
+modifications to the YAML.
 
 
 ## Usage
@@ -574,6 +575,14 @@ A repository rule that allows users to alias `k8s_object` with default values.
       <td>
         <p><code>string, optional</code></p>
         <p>The repository under which to actually publish Docker images.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>resolver</code></td>
+      <td>
+        <p><code>target, optional</code></p>
+        <p>A build target for the binary that's called to resolves references
+           inside the Kubernetes YAML files.</p>
       </td>
     </tr>
   </tbody>

--- a/k8s/object.bzl
+++ b/k8s/object.bzl
@@ -90,7 +90,7 @@ def _impl(ctx):
   ctx.actions.expand_template(
       template = ctx.file._template,
       substitutions = {
-        "%{resolver}": _runfiles(ctx, ctx.executable._resolver),
+        "%{resolver}": _runfiles(ctx, ctx.executable.resolver),
         "%{yaml}": _runfiles(ctx, ctx.file.template),
         "%{image_chroot}": image_chroot_arg,
         "%{images}": " ".join([
@@ -102,9 +102,9 @@ def _impl(ctx):
   )
 
   return struct(runfiles = ctx.runfiles(files = [
-    ctx.executable._resolver,
+    ctx.executable.resolver,
     ctx.file.template,
-  ] + list(ctx.attr._resolver.default_runfiles.files) + all_inputs))
+  ] + list(ctx.attr.resolver.default_runfiles.files) + all_inputs))
 
 def _resolve(ctx, string, output):
   stamps = [ctx.info_file, ctx.version_file]
@@ -124,7 +124,7 @@ def _resolve(ctx, string, output):
   )
 
 def _common_impl(ctx):
-  files = [ctx.executable._resolver]
+  files = [ctx.executable.resolver]
 
   cluster_arg = ctx.attr.cluster
   if "{" in ctx.attr.cluster:
@@ -173,7 +173,7 @@ _common_attrs = {
     # This is only needed for describe.
     "kind": attr.string(),
     "image_chroot": attr.string(),
-    "_resolver": attr.label(
+    "resolver": attr.label(
         default = Label("//k8s:resolver"),
         cfg = "host",
         executable = True,


### PR DESCRIPTION
The custom resolver mattmoor@ mentioned seems to be a very workable solution for endpoint resolving (#88). I've made a PoC implementation in http://shortn/_0SyJs3BlK7 (Google-internal link) that uses a custom resolver to resolve endpoint versions after Docker digests were resolved. Could you PTAL?