### PR TITLE
describe: get the object kind from the config

### DIFF
--- a/k8s/describe.sh.tpl
+++ b/k8s/describe.sh.tpl
@@ -23,7 +23,9 @@ function guess_runfiles() {
 
 RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
 
-RESOURCE_NAME=$(kubectl create --dry-run -f "%{unresolved}" | cut -d'"' -f 2)
-
-kubectl --cluster="%{cluster}" %{namespace_arg} describe %{kind} \
-  "${RESOURCE_NAME}"
+kubectl create --dry-run -f "%{unresolved}" | tr -d '"' | \
+  while IFS=" " read -r KIND RESOURCE_NAME remainder
+  do
+    kubectl --cluster="%{cluster}" %{namespace_arg} describe "${KIND}" \
+      "${RESOURCE_NAME}"
+  done


### PR DESCRIPTION
This should fix #113 by showing all resources found in the config.

Does this mean we can actually remove the "kind" attribute from the bazel rules and instead always read it from the config directly - like we're doing here?

I believe that with this change, we don't need `kind` anywhere else, or do we?