### PR TITLE
Fix file reference to rules_docker

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,7 +15,7 @@ workspace(name = "io_bazel_rules_k8s")
 
 git_repository(
     name = "io_bazel_rules_docker",
-    commit = "1813f65a331d2cf8f891d85245da43d3707072e9",
+    commit = "27c94dec66c3c9fdb478c33994471c5bfc15b6eb",
     remote = "https://github.com/bazelbuild/rules_docker.git",
 )
 

--- a/k8s/object.bzl
+++ b/k8s/object.bzl
@@ -14,7 +14,7 @@
 """An implementation of k8s_object for interacting with an object of kind."""
 
 load(
-    "@io_bazel_rules_docker//container:layers.bzl",
+    "@io_bazel_rules_docker//container:layer_tools.bzl",
     _get_layers = "get_from_target",
     _layer_tools = "tools",
 )


### PR DESCRIPTION
The file was renamed in https://github.com/bazelbuild/rules_docker/pull/279.