### PR TITLE
Improve "not found" error message (#121)

### DIFF
--- a/k8s/resolver.py
+++ b/k8s/resolver.py
@@ -188,9 +188,10 @@ def main():
   content = Resolve(inputs, _StringToDigest)
 
   if len(unseen_strings) > 0:
-    print('The following image references were not found: [%s]' % "\n".join([
-      str(x) for x in unseen_strings
-    ]),file=sys.stderr)
+    print('ERROR: The following image references were not found in %r:' %
+          args.template, file=sys.stderr)
+    for ref in unseen_strings:
+      print('    %s' % ref, file=sys.stderr)
     sys.exit(1)
 
   print(content)


### PR DESCRIPTION
The current message:

```
The following image references were not found: [eu.gcr.io/robco-rodrigoq/move-endpoint:latest]
```

suggests to the untrained eye that they should check that image has not
been found on the container registry, as the user may not know that the
resolver is replacing image references inside the YAML file.

This commit changes the message to:

```
ERROR: The following image references were not found in '/your/bazel/cache/dir/execroot/__main__bazel-out/k8-opt/bin/your/package/path/k8s.runfiles/__main__/your/package/path/deployment.yaml':
    eu.gcr.io/robco-rodrigoq/move-endpoint:latest
```

which is very long but hopefully clearer, as the user can look at that
file to work out why the image reference is not found.