### PR TITLE
(#125) Minimal travis reproduction of rules_docker regression.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,11 +30,19 @@ before_install:
 install:
   - go get -u github.com/bazelbuild/buildifier/buildifier
 
+env:
+  - USE_RULES_DOCKER_HEAD=true
+  - USE_RULES_DOCKER_HEAD=false
+
 script:
   # Check our installs.
   - bazel version
   - gcloud version
   - kubectl version
+
+  - [[ "${USE_RULES_DOCKER_HEAD}" == "true" ]] &&
+    sed -i.bak "s/27c94dec66c3c9fdb478c33994471c5bfc15b6eb/4d8ec6570a5313fb0128e2354f2bc4323685282a/" WORKSPACE &&
+    rm WORKSPACE.bak
 
   # Check that all of our tools and samples build
   - bazel clean && bazel build //...


### PR DESCRIPTION
If you run set the new version of `rules_docker`, you will see the failure. E.g.:

```
~/development/rules_k8s (rules_docker_integration_test)$ sed -i.bak "s/27c94dec66c3c9fdb478c33994471c5bfc15b6eb/4d8ec6570a5313fb0128e2354f2bc4323685282a/" WORKSPACE && rm WORKSPACE.bak
~/development/rules_k8s (rules_docker_integration_test *)$ bazel test //...
INFO: Analysed 186 targets (174 packages loaded).
INFO: Found 183 targets and 3 test targets...
ERROR: /Users/gdonovan/development/rules_k8s/examples/hellohttp/java/BUILD:30:1: ExtractConfig examples/hellohttp/java/staging.server-layer.tar.config failed (Exit 1)
Traceback (most recent call last):
  File "/private/var/tmp/_bazel_gdonovan/71238990bba152dc4d89e2a173c81413/bazel-sandbox/7805156306156731437/execroot/io_bazel_rules_k8s/bazel-out/host/bin/external/io_bazel_rules_docker/container/extract_config.runfiles/io_bazel_rules_k8s/../io_bazel_rules_docker/container/extract_config.py", line 43, in <module>
    main()
  File "/private/var/tmp/_bazel_gdonovan/71238990bba152dc4d89e2a173c81413/bazel-sandbox/7805156306156731437/execroot/io_bazel_rules_k8s/bazel-out/host/bin/external/io_bazel_rules_docker/container/extract_config.runfiles/io_bazel_rules_k8s/../io_bazel_rules_docker/container/extract_config.py", line 37, in main
    with docker_image.FromTarball(args.tarball) as img:
  File "/private/var/tmp/_bazel_gdonovan/71238990bba152dc4d89e2a173c81413/bazel-sandbox/7805156306156731437/execroot/io_bazel_rules_k8s/bazel-out/host/bin/external/io_bazel_rules_docker/container/extract_config.runfiles/containerregistry/client/v2_2/docker_image_.py", line 550, in __enter__
    manifest_json = self._content('manifest.json')
  File "/private/var/tmp/_bazel_gdonovan/71238990bba152dc4d89e2a173c81413/bazel-sandbox/7805156306156731437/execroot/io_bazel_rules_k8s/bazel-out/host/bin/external/io_bazel_rules_docker/container/extract_config.runfiles/containerregistry/client/v2_2/docker_image_.py", line 435, in _content
    content = tar.extractfile('./' + name).read()
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/tarfile.py", line 2136, in extractfile
    tarinfo = self.getmember(member)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/tarfile.py", line 1821, in getmember
    raise KeyError("filename %r not found" % name)
KeyError: "filename './manifest.json' not found"
INFO: Elapsed time: 5.141s, Critical Path: 1.93s
FAILED: Build did NOT complete successfully
//examples/hellogrpc:deployment_test                            (cached) PASSED in 1.2s
//examples/hellohttp:deployment_test                            (cached) PASSED in 1.2s
//k8s:resolver_test                                                   NO STATUS

Executed 0 out of 3 tests: 2 tests pass and 1 was skipped.
```