### PR TITLE
Fix k8s_object to work with latest rules_docker

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,7 +15,7 @@ workspace(name = "io_bazel_rules_k8s")
 
 git_repository(
     name = "io_bazel_rules_docker",
-    commit = "27c94dec66c3c9fdb478c33994471c5bfc15b6eb",
+    commit = "452878d665648ada0aaf816931611fdd9c683a97",
     remote = "https://github.com/bazelbuild/rules_docker.git",
 )
 

--- a/k8s/object.bzl
+++ b/k8s/object.bzl
@@ -55,8 +55,6 @@ def _impl(ctx):
     # Compute the set of layers from the image_targets.
     image_target_dict = _string_to_label(
         ctx.attr.image_targets, ctx.attr.image_target_strings)
-    image_files_dict = _string_to_label(
-        ctx.files.image_targets, ctx.attr.image_target_strings)
 
     # Walk the collection of images passed and for each key/value pair
     # collect the parts to pass to the resolver as --image_spec arguments.
@@ -65,7 +63,7 @@ def _impl(ctx):
     # to include as runfiles, so they are accessible to be pushed.
     for tag in ctx.attr.images:
       target = ctx.attr.images[tag]
-      image = _get_layers(ctx, image_target_dict[target], image_files_dict[target])
+      image = _get_layers(ctx, image_target_dict[target])
 
       image_spec = {"name": tag}
       if image.get("legacy"):


### PR DESCRIPTION
I don't really understand this change that well; I'm just mirroring the refactoring in https://github.com/bazelbuild/rules_docker/pull/340/commits/7228cb2764c519408478c70c6865090bdb856be7.

It seems to build, so maybe it's correct? I'm not sure if there's semantic meaning I'm missing, though.

Fixes #125