### PR TITLE
Support resolving image refs within YAML, not just exact matches of a full string.

### DIFF
--- a/k8s/resolver.py
+++ b/k8s/resolver.py
@@ -85,7 +85,7 @@ def StringToDigest(string, overrides, transport):
   """Replace all keys in the string with fully qualify digests."""
   replaced_string = string
   for override, digest in overrides.items():
-    replaced_string = string.replace(override, digest)
+    replaced_string = string.replace(override, str(digest))
   if replaced_string != string:
     # Once we've found a match, don't attempt to turn string into a tag
     return replaced_string

--- a/k8s/resolver.py
+++ b/k8s/resolver.py
@@ -82,9 +82,13 @@ def Resolve(input, string_to_digest):
 
 
 def StringToDigest(string, overrides, transport):
-  """Turn a string into a stringified digest."""
-  if string in overrides:
-    return str(overrides[string])
+  """Replace all keys in the string with fully qualify digests."""
+  replaced_string = string
+  for override, digest in overrides.items():
+    replaced_string = string.replace(override, digest)
+  if replaced_string != string:
+    # Once we've found a match, don't attempt to turn string into a tag
+    return replaced_string
 
   # Attempt to turn the string into a tag, this may throw.
   tag = docker_name.Tag(string)

--- a/k8s/resolver.py
+++ b/k8s/resolver.py
@@ -85,7 +85,7 @@ def StringToDigest(string, overrides, transport):
   """Replace all keys in the string with fully qualify digests."""
   replaced_string = string
   for override, digest in overrides.items():
-    replaced_string = string.replace(override, str(digest))
+    replaced_string = replaced_string.replace(override, str(digest))
   if replaced_string != string:
     # Once we've found a match, don't attempt to turn string into a tag
     return replaced_string

--- a/k8s/resolver_test.py
+++ b/k8s/resolver_test.py
@@ -90,6 +90,19 @@ key1:
     }, _BAD_TRANSPORT)
     self.assertEqual(actual_digest, expected_digest)
 
+  def test_tag_embedded_in_metadata(self):
+    """Test that image refs embedded within a YAML string are replaced. This can happen, e.g.,
+    when using spec->template->metadata->annotations.pod.beta.kubernetes.io/init-containers
+    """
+    metadata = '[{"command": ["/some/example/command/example.sh"], "image": "%s"}]'
+    sentinel_string = 'XXXXX'
+    sentinel_within_metadata = metadata % sentinel_string
+    expected_digest = 'gcr.io/foo/bar@sha256:deadbeef'
+    actual_digest = resolver.StringToDigest(sentinel_within_metadata, {
+      sentinel_string: expected_digest,
+    }, _BAD_TRANSPORT)
+    self.assertEqual(actual_digest, metadata % expected_digest)
+
   def test_tag_to_digest_not_cached(self):
     with v2_2_image.FromTarball(TestData(
         'io_bazel_rules_k8s/examples/hellogrpc/cc/server/server.tar')) as img:


### PR DESCRIPTION
This can be useful, e.g., when using `spec->template->metadata->annotations.pod.beta.kubernetes.io/init-containers` and embedding image references within a larger JSON string containing a full container description. See the workarounds described in https://github.com/kubernetes/kubernetes/issues/47264 for our motivating example.

