### PR TITLE
fix hellogrpc/py examples by adding dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ addons:
 
 before_install:
   # Log into GCR
-  - docker login -u _json_key -p "${GOOGLE_JSON_KEY}" https://us.gcr.io
+  - echo "${GOOGLE_JSON_KEY}" | docker login -u _json_key --password-stdin https://us.gcr.io
   # Log into gcloud
   - echo -n "${GOOGLE_JSON_KEY}" > keyfile.json
   - gcloud auth activate-service-account --key-file keyfile.json

--- a/examples/hellogrpc/py/requirements.txt
+++ b/examples/hellogrpc/py/requirements.txt
@@ -1,1 +1,2 @@
 grpcio==1.6.0
+setuptools==39.2.0

--- a/examples/hellogrpc/py/server/BUILD
+++ b/examples/hellogrpc/py/server/BUILD
@@ -28,6 +28,7 @@ py_image(
     # unchanging and we can reduce the amount of image data we repush by ~99%!
     layers = [
         requirement("grpcio"),
+        requirement("setuptools"),
         "//examples/hellogrpc/proto:py",
     ],
     main = "server.py",


### PR DESCRIPTION
* All current Travis CI would fail because hellogrpc/py e2e test would
  fail. This PR fix this test, so that Travis CI works again.

* hellogprc/py server would produce a py_image which is failed to
  start because of missing a dependency:

``` bash
Traceback (most recent call last):
  File "/app/hello_grpc/py/server/server.binary.runfiles/__main__/hello_grpc/py/server/server.py", line 1, in <module>
    import grpc
  File "/app/hello_grpc/py/server/server.binary.runfiles/pypi__grpcio_1_6_0/grpc/__init__.py", line 22, in <module>
    from grpc._cython import cygrpc as _cygrpc
  File "src/python/grpcio/grpc/_cython/cygrpc.pyx", line 17, in init grpc._cython.cygrpc (src/python/grpcio/grpc/_cython/cygrpc.c:29041)
```

* Adding setuptools in requirements fixes the problem.