### PR TITLE
Create root-level OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,16 @@
+# See Config struct in https://github.com/kubernetes/test-infra/blob/master/prow/repoowners/repoowners.go
+
+# Reviewers may be auto-assigned by blunderbuss
+reviewers:
+- erain
+- fejta
+- nlopezgi
+
+# Approvers can /approve changes to files within this directory tree.
+approvers:
+- dlorenc
+- erain
+- fejta
+- mattmoor
+- nlopezgi
+- xingao267


### PR DESCRIPTION
/assign @erain 

After this `/approve` should work as expected.

Do we want to enable blunderbuss to have prow automatically assign a reviewer on new PRs?