### PR TITLE
Create a test-e2e.sh script which prow can run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,8 +28,9 @@
 *.out
 *.app
 
-# Emacs garbage
+# Emacs/vim garbage
 *~
+*.swp
 
 # Bazel directories
 bazel-*

--- a/examples/hellohttp/BUILD
+++ b/examples/hellohttp/BUILD
@@ -22,6 +22,13 @@ k8s_deploy(
     template = "deployment.yaml",
 )
 
+load("@k8s_service//:defaults.bzl", "k8s_service")
+
+k8s_deploy(
+    name = "staging-service",
+    template = "service.yaml",
+)
+
 load("@io_bazel_rules_jsonnet//jsonnet:jsonnet.bzl", "jsonnet_to_json")
 
 jsonnet_to_json(

--- a/examples/hellohttp/service.yaml
+++ b/examples/hellohttp/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: hello-http-staging
+  name: hello-http-staging
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: hello-http-staging
+  type: LoadBalancer

--- a/test-e2e.sh
+++ b/test-e2e.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+
+check-plat() {
+  local plat="$(uname -s)"
+  if [[ $plat != Linux ]]; then
+	  echo "System must be Linux, found: $plat"
+	  return 1
+  fi
+}
+
+check-plat
+
+if [[ -n "${HELLO_WORLD:-}" ]]; then
+  # Log into GCR
+  docker login -u _json_key -p "${GOOGLE_JSON_KEY}" https://us.gcr.io
+  # Log into gcloud
+  echo -n "${GOOGLE_JSON_KEY}" > keyfile.json
+  gcloud auth activate-service-account --key-file keyfile.json
+  rm -f keyfile.json
+  gcloud config set core/project rules-k8s
+  gcloud config set compute/zone us-central1-f
+  gcloud container clusters get-credentials testing
+fi
+# Check our installs.
+bazel version
+gcloud version
+kubectl version
+
+# Check that all of our tools and samples build
+bazel clean && bazel build //...
+# Check that all of our tests pass
+bazel clean && bazel test //...
+
+# Run end-to-end integration testing.
+# First, GRPC.
+./examples/hellogrpc/e2e-test.sh cc java go py
+# Second, HTTP.
+./examples/hellohttp/e2e-test.sh java go py nodejs
+# Third, TODO Controller.
+./examples/todocontroller/e2e-test.sh py


### PR DESCRIPTION
/assign @erain 

* Check in the `hellohttp` service
* Update The `hellohttp`, `hellogrpc` test scripts to
  - accept a list of languages (rather than just one)
  - ensure the service exists
  - print out all the app's resources before deletion
* Create a top-level `test-e2e.sh` that runs all the e2e tests
  - essentially a clone of `.travis.yml`
  - will be used by prow