### PR TITLE
Use /usr/bin/env bash for more portable shebang lines

### DIFF
--- a/examples/hellogrpc/cc/server/edit.sh
+++ b/examples/hellogrpc/cc/server/edit.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #

--- a/examples/hellogrpc/e2e-test.sh
+++ b/examples/hellogrpc/e2e-test.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #

--- a/examples/hellogrpc/go/server/edit.sh
+++ b/examples/hellogrpc/go/server/edit.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #

--- a/examples/hellogrpc/java/server/edit.sh
+++ b/examples/hellogrpc/java/server/edit.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #

--- a/examples/hellogrpc/py/server/edit.sh
+++ b/examples/hellogrpc/py/server/edit.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #

--- a/examples/hellohttp/e2e-test.sh
+++ b/examples/hellohttp/e2e-test.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #

--- a/examples/hellohttp/go/edit.sh
+++ b/examples/hellohttp/go/edit.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #

--- a/examples/hellohttp/java/edit.sh
+++ b/examples/hellohttp/java/edit.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #

--- a/examples/hellohttp/nodejs/edit.sh
+++ b/examples/hellohttp/nodejs/edit.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #

--- a/examples/hellohttp/py/edit.sh
+++ b/examples/hellohttp/py/edit.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #

--- a/examples/todocontroller/e2e-test.sh
+++ b/examples/todocontroller/e2e-test.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #

--- a/examples/todocontroller/py/edit.sh
+++ b/examples/todocontroller/py/edit.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #

--- a/k8s/apply.sh.tpl
+++ b/k8s/apply.sh.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #

--- a/k8s/create.sh.tpl
+++ b/k8s/create.sh.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #

--- a/k8s/delete.sh.tpl
+++ b/k8s/delete.sh.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #

--- a/k8s/describe.sh.tpl
+++ b/k8s/describe.sh.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #

--- a/k8s/replace.sh.tpl
+++ b/k8s/replace.sh.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #

--- a/k8s/resolve-all.sh.tpl
+++ b/k8s/resolve-all.sh.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #

--- a/k8s/resolve.sh.tpl
+++ b/k8s/resolve.sh.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #

--- a/k8s/reverse.sh.tpl
+++ b/k8s/reverse.sh.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #

--- a/test-e2e.sh
+++ b/test-e2e.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #


### PR DESCRIPTION
There are still systems widely in use where bash does not exist at `/bin/bash` (e.g. NixOS), or where `/bin/bash` is an extremely outdated version of bash (MacOS).  Using `/usr/bin/env` to locate bash increases portability.  It's not hermetic, but `/bin/bash` was already not hermetic.