### PR TITLE
Exit the resolver if publishing fails

### DIFF
--- a/k8s/resolver.py
+++ b/k8s/resolver.py
@@ -182,6 +182,7 @@ def main():
       unseen_strings.add(tag)
     except Exception as e:
       logging.fatal('Error publishing provided image: %s', e)
+      sys.exit(1)
 
   with open(args.template, 'r') as f:
     inputs = f.read()


### PR DESCRIPTION
Currently, when there is a problem publishing an image a message will be printed to stderr, but the resolver still tries to resolve the template anyway. The output _looks_ successful (valid yaml on stdout and a returncode of 0) but has one or more problems:
- Image is output unmodified (tag not resolved to a digest)
- Image is resolved to the currently published digest (ie not the digest of the container_image dependency)

It turns out `logging.fatal()` is actually an alias for `logging.critical()` (which does not exit the process when invoked), thus the need for explicitly exiting.