### PR TITLE
Add logic to generate bazel + gcloud container using rules_docker

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -12,6 +12,9 @@ platforms:
     - "..."
   macos:
     build_targets:
+    - "--"
     - "..."
+    - "-//images/gcloud-bazel:gcloud_install"
+    - "-//images/gcloud-bazel:gcloud_push"
     test_targets:
     - "..."

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -23,9 +23,38 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_docker/archive/4282829a554058401f7ff63004c8870c8d35e29c.tar.gz"],
 )
 
+#http_archive(
+#    name = "base_images_docker",
+#    sha256 = "e2b1b7254270bb7605e814a9dbf6d1e4ae04a11136ff1714fbfdabe3f87f7cf9",
+#    strip_prefix = "base-images-docker-12801524f867e657fbb5d1a74f31618aff181ac6",
+#    urls = ["https://github.com/GoogleCloudPlatform/base-images-docker/archive/12801524f867e657fbb5d1a74f31618aff181ac6.tar.gz"],
+#)
+
 load(
     "@io_bazel_rules_docker//docker:docker.bzl",
     "docker_repositories",
+)
+load(
+    "@io_bazel_rules_docker//container:container.bzl",
+    "container_pull",
+)
+
+container_pull(
+    name = "bazel_image",
+    registry = "launcher.gcr.io",
+    repository = "google/bazel",
+)
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+
+# Gcloud installer
+http_file(
+    name = "gcloud_archive",
+    downloaded_file_path = "google-cloud-sdk.tar.gz",
+    sha256 = "a2205e35b11136004d52d47774762fbec9145bf0bda74ca506f52b71452c570e",
+    urls = [
+        "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-220.0.0-linux-x86_64.tar.gz",
+    ],
 )
 
 docker_repositories()
@@ -35,6 +64,7 @@ load("//k8s:k8s.bzl", "k8s_repositories", "k8s_defaults")
 k8s_repositories()
 
 _CLUSTER = "gke_rules-k8s_us-central1-f_testing"
+
 _CONTEXT = _CLUSTER
 
 _NAMESPACE = "{BUILD_USER}"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -23,13 +23,6 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_docker/archive/4282829a554058401f7ff63004c8870c8d35e29c.tar.gz"],
 )
 
-#http_archive(
-#    name = "base_images_docker",
-#    sha256 = "e2b1b7254270bb7605e814a9dbf6d1e4ae04a11136ff1714fbfdabe3f87f7cf9",
-#    strip_prefix = "base-images-docker-12801524f867e657fbb5d1a74f31618aff181ac6",
-#    urls = ["https://github.com/GoogleCloudPlatform/base-images-docker/archive/12801524f867e657fbb5d1a74f31618aff181ac6.tar.gz"],
-#)
-
 load(
     "@io_bazel_rules_docker//docker:docker.bzl",
     "docker_repositories",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -17,6 +17,13 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
+    name = "base_images_docker",
+    sha256 = "c491e669299c842da1c1767c5bde73c3740b2fae19b9e38dae1732ca1725a2ef",
+    strip_prefix = "base-images-docker-635108c36ae89167a3ca8eb53706aed641145177",
+    urls = ["https://github.com/GoogleCloudPlatform/base-images-docker/archive/635108c36ae89167a3ca8eb53706aed641145177.tar.gz"],
+)
+
+http_archive(
     name = "io_bazel_rules_docker",
     sha256 = "35c585261362a96b1fe777a7c4c41252b22fd404f24483e1c48b15d7eb2b55a5",
     strip_prefix = "rules_docker-4282829a554058401f7ff63004c8870c8d35e29c",

--- a/images/gcloud-bazel/BUILD.bazel
+++ b/images/gcloud-bazel/BUILD.bazel
@@ -12,18 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO(fejta): replace Dockerfile with an equivalent bazel rule. This seems promising:
-#   https://github.com/GoogleContainerTools/base-images-docker/blob/master/package_managers/bootstrap_image.bzl
-
 load("@io_bazel_rules_docker//container:image.bzl", "container_image")
 load("@io_bazel_rules_docker//container:layer.bzl", "container_layer")
 load("@io_bazel_rules_docker//container:push.bzl", "container_push")
 load("@base_images_docker//util:run.bzl", "container_run_and_commit")
 
-# Gcloud layer. Simply includes an extractec version of the gcloud installation
-# archive. Gcloud isn't fully installed as a result of this. The final containe
-# needs to run /google-cloud-sdk/install.sh -q and source /google-cloud-sdk/path.bash.inc
-# in their bashrc to complete the gcloud installation
+# Includes the gcloud installation archive
 container_layer(
     name = "gcloud-layer",
     tars = [
@@ -31,10 +25,10 @@ container_layer(
     ],
 )
 
-# Build an image that uses the official bazel base image and includes the gcloud
-# layer on top
+# Build an image that uses the official bazel base image and includes the
+# gcloud layer on top
 container_image(
-    name = "image_intermediate",
+    name = "gcloud_installer",
     base = "@bazel_image//image",
     layers=[
         ":gcloud-layer",
@@ -46,8 +40,8 @@ container_image(
 # Bootstrap the container image by installing some additional
 # packages and running some post install steps
 container_run_and_commit(
-    name = "image",
-    image=":image_intermediate.tar",
+    name = "gcloud_install",
+    image=":gcloud_installer.tar",
     commands = [
         # Finalize the gcloud installation
         "/google-cloud-sdk/install.sh -q",
@@ -62,11 +56,11 @@ container_run_and_commit(
     ],
 )
 
-# Push the container to the image used by the K8s CI pod spec
+# Push the container so it can be used by the K8s CI pod spec
 # Pod spec: https://github.com/kubernetes/test-infra/blob/master/config/jobs/bazelbuild/rules_k8s/rules_k8s_config.yaml
 container_push(
-    name="image-push",
-    image=":image_commit.tar",
+    name="gcloud-push",
+    image=":gcloud_install_commit.tar",
     format="Docker",
     registry="gcr.io",
     repository="rules-k8s/gcloud-bazel",

--- a/images/gcloud-bazel/BUILD.bazel
+++ b/images/gcloud-bazel/BUILD.bazel
@@ -17,8 +17,6 @@
 
 load("@io_bazel_rules_docker//container:image.bzl", "container_image")
 load("@io_bazel_rules_docker//container:layer.bzl", "container_layer")
-#load("@base_images_docker//package_managers:bootstrap_image.bzl",
-#    "bootstrap_image_macro")
 
 # Gcloud layer. Simply includes an extractec version of the gcloud installation
 # archive. Gcloud isn't fully installed as a result of this. The final containe
@@ -43,29 +41,13 @@ container_image(
     entrypoint = "",
 )
 
-# Bootstrap the container image by installing some additional packages and
-# running a few post install steps. Currently fails because the config_stripper
-# logic in base_images_docker doesn't handle layers that are symlinked to other
-# layers. Need to look into whether the symlinking is an error or config_stripper
-# needs to be updated to handle that scenario
-#bootstrap_image_macro(
-#    name="image",
-#
-#    date="$DATE",
-#    image_tar=":image-intermediate.tar",
-#    packages=[
-#        "python-pip",
-#    ],
-#    installation_cleanup_commands= " && ".join([
-#        # Finalize the google cloud installation
-#        "/google-cloud-sdk/install.sh -q",
-#        # Add the google cloud sdk binaries to the PATH
-#        "echo 'source /google-cloud-sdk/path.bash.inc' >> ~/.bashrc",
-#        "apt-get clean",
-#        "python -m pip install --upgrade pip setuptools wheel",
-#        # Install kubernetes
-#        "/google-cloud-sdk/bin/gcloud components install --quiet kubectl",
-#    ]),
-#    store_location="images/gcloud-bazel/bootsteap_image_macro",
-#    output_image_name="gcr.io/rules-k8s/gcloud-bazel",
-#)
+# TODO (smukherj1): Bootstrap the container image by installing some additional
+# packages and running the following post install steps:-
+# 1. Run /google/cloud-sdk/install.sh -q to extract the google-gcloud-sdk
+#    installation
+# 2. Add "source /google-cloud-sdk/path.bash.inc" to PATH to ensure gcloud
+#    binaries are in the path
+# 3. Run python -m pip install --upgrade pip setuptools wheel to install the
+#    latest version of pip, setuptools and wheel
+# 4. Run /google-cloud-sdk/bin/gcloud components install --quiet kubectl to
+#    install kubernetes as a component of gcloud

--- a/images/gcloud-bazel/BUILD.bazel
+++ b/images/gcloud-bazel/BUILD.bazel
@@ -14,3 +14,58 @@
 
 # TODO(fejta): replace Dockerfile with an equivalent bazel rule. This seems promising:
 #   https://github.com/GoogleContainerTools/base-images-docker/blob/master/package_managers/bootstrap_image.bzl
+
+load("@io_bazel_rules_docker//container:image.bzl", "container_image")
+load("@io_bazel_rules_docker//container:layer.bzl", "container_layer")
+#load("@base_images_docker//package_managers:bootstrap_image.bzl",
+#    "bootstrap_image_macro")
+
+# Gcloud layer. Simply includes an extractec version of the gcloud installation
+# archive. Gcloud isn't fully installed as a result of this. The final containe
+# needs to run /google-cloud-sdk/install.sh -q and source /google-cloud-sdk/path.bash.inc
+# in their bashrc to complete the gcloud installation
+container_layer(
+    name = "gcloud-layer",
+    tars = [
+        "@gcloud_archive//file",
+    ],
+)
+
+# Build an image that uses the official bazel base image and includes the gcloud
+# layer on top
+container_image(
+    name = "image",
+    base = "@bazel_image//image",
+    layers=[
+        ":gcloud-layer",
+    ],
+    cmd = "",
+    entrypoint = "",
+)
+
+# Bootstrap the container image by installing some additional packages and
+# running a few post install steps. Currently fails because the config_stripper
+# logic in base_images_docker doesn't handle layers that are symlinked to other
+# layers. Need to look into whether the symlinking is an error or config_stripper
+# needs to be updated to handle that scenario
+#bootstrap_image_macro(
+#    name="image",
+#
+#    date="$DATE",
+#    image_tar=":image-intermediate.tar",
+#    packages=[
+#        "python-pip",
+#    ],
+#    installation_cleanup_commands= " && ".join([
+#        # Finalize the google cloud installation
+#        "/google-cloud-sdk/install.sh -q",
+#        # Add the google cloud sdk binaries to the PATH
+#        "echo 'source /google-cloud-sdk/path.bash.inc' >> ~/.bashrc",
+#        "apt-get clean",
+#        "python -m pip install --upgrade pip setuptools wheel",
+#        # Install kubernetes
+#        "/google-cloud-sdk/bin/gcloud components install --quiet kubectl",
+#    ]),
+#    store_location="images/gcloud-bazel/bootsteap_image_macro",
+#    output_image_name="gcr.io/rules-k8s/gcloud-bazel",
+#)

--- a/images/gcloud-bazel/BUILD.bazel
+++ b/images/gcloud-bazel/BUILD.bazel
@@ -59,7 +59,7 @@ container_run_and_commit(
 # Push the container so it can be used by the K8s CI pod spec
 # Pod spec: https://github.com/kubernetes/test-infra/blob/master/config/jobs/bazelbuild/rules_k8s/rules_k8s_config.yaml
 container_push(
-    name="gcloud-push",
+    name="gcloud_push",
     image=":gcloud_install_commit.tar",
     format="Docker",
     registry="gcr.io",

--- a/images/gcloud-bazel/BUILD.bazel
+++ b/images/gcloud-bazel/BUILD.bazel
@@ -17,6 +17,8 @@
 
 load("@io_bazel_rules_docker//container:image.bzl", "container_image")
 load("@io_bazel_rules_docker//container:layer.bzl", "container_layer")
+load("@io_bazel_rules_docker//container:push.bzl", "container_push")
+load("@base_images_docker//util:run.bzl", "container_run_and_commit")
 
 # Gcloud layer. Simply includes an extractec version of the gcloud installation
 # archive. Gcloud isn't fully installed as a result of this. The final containe
@@ -32,7 +34,7 @@ container_layer(
 # Build an image that uses the official bazel base image and includes the gcloud
 # layer on top
 container_image(
-    name = "image",
+    name = "image_intermediate",
     base = "@bazel_image//image",
     layers=[
         ":gcloud-layer",
@@ -41,13 +43,33 @@ container_image(
     entrypoint = "",
 )
 
-# TODO (smukherj1): Bootstrap the container image by installing some additional
-# packages and running the following post install steps:-
-# 1. Run /google/cloud-sdk/install.sh -q to extract the google-gcloud-sdk
-#    installation
-# 2. Add "source /google-cloud-sdk/path.bash.inc" to PATH to ensure gcloud
-#    binaries are in the path
-# 3. Run python -m pip install --upgrade pip setuptools wheel to install the
-#    latest version of pip, setuptools and wheel
-# 4. Run /google-cloud-sdk/bin/gcloud components install --quiet kubectl to
-#    install kubernetes as a component of gcloud
+# Bootstrap the container image by installing some additional
+# packages and running some post install steps
+container_run_and_commit(
+    name = "image",
+    image=":image_intermediate.tar",
+    commands = [
+        # Finalize the gcloud installation
+        "/google-cloud-sdk/install.sh -q",
+        # Add the gcloud binaries to PATH
+        "echo 'source /google-cloud-sdk/path.bash.inc' >> ~/.bashrc",
+        "apt-get update",
+        "apt-get install -y --no-install-recommends python-pip",
+        "apt-get clean",
+        "python -m pip install --upgrade pip setuptools wheel",
+        # Install kubernetes as a component of gcloud
+        "/google-cloud-sdk/bin/gcloud components install --quiet kubectl",
+    ],
+)
+
+# Push the container to the image used by the K8s CI pod spec
+# Pod spec: https://github.com/kubernetes/test-infra/blob/master/config/jobs/bazelbuild/rules_k8s/rules_k8s_config.yaml
+container_push(
+    name="image-push",
+    image=":image_commit.tar",
+    format="Docker",
+    registry="gcr.io",
+    repository="rules-k8s/gcloud-bazel",
+    tag="latest",
+)
+

--- a/images/gcloud-bazel/Dockerfile
+++ b/images/gcloud-bazel/Dockerfile
@@ -31,19 +31,13 @@ RUN apt-key add /gcloud.pub.gpg \
 COPY sources.list /etc/apt/sources.list.d/gcloud.list
 
 # Install necessary dependencies:
-# * curl: needed by examples/hellohttp/e2e-test.sh
 # * gcloud: needed by rules_go and test-e2e.sh
-# * git: needed by rules_go
 # * kubectl: needed by rules_k8s
-# * openjdk-8-jdk: bazel
 # * pip setuptools wheel: needed by python rules
 # * python-pip: needed by python rules
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl \
     google-cloud-sdk \
-    git \
     kubectl \
-    openjdk-8-jdk \
     python-pip \
     && apt-get clean \
     && python -m pip install --upgrade pip setuptools wheel

--- a/images/gcloud-bazel/Dockerfile
+++ b/images/gcloud-bazel/Dockerfile
@@ -14,7 +14,7 @@
 
 # Ubuntu with bazel, gcloud and its dependencies preinstalled.
 
-FROM launcher.gcr.io/google/ubuntu16_04:latest
+FROM launcher.gcr.io/google/bazel:latest
 # Based off github.com/kubernetes/test-infra/images/bazelbuild
 LABEL maintainer="fejta@google.com"
 
@@ -23,16 +23,14 @@ LABEL maintainer="fejta@google.com"
 # * https://cloud.google.com/sdk/docs/downloads-apt-get
 
 # Ensure new repos aren't compromised.
-COPY bazel.pub.gpg gcloud.pub.gpg /
-RUN apt-key add /bazel.pub.gpg \
-    && apt-key add /gcloud.pub.gpg \
-    && rm /bazel.pub.gpg /gcloud.pub.gpg
+COPY gcloud.pub.gpg /
+RUN apt-key add /gcloud.pub.gpg \
+    && rm /gcloud.pub.gpg
 
 # Add new repos to install bazel and google-cloud-sdk (including kubectl)
-COPY sources.list /etc/apt/sources.list.d/bazel-gcloud.list
+COPY sources.list /etc/apt/sources.list.d/gcloud.list
 
 # Install necessary dependencies:
-# * bazel: needed by test-e2e.sh
 # * curl: needed by examples/hellohttp/e2e-test.sh
 # * gcloud: needed by rules_go and test-e2e.sh
 # * git: needed by rules_go
@@ -41,7 +39,6 @@ COPY sources.list /etc/apt/sources.list.d/bazel-gcloud.list
 # * pip setuptools wheel: needed by python rules
 # * python-pip: needed by python rules
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    bazel \
     curl \
     google-cloud-sdk \
     git \

--- a/images/gcloud-bazel/sources.list
+++ b/images/gcloud-bazel/sources.list
@@ -1,2 +1,1 @@
-deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8
 deb http://packages.cloud.google.com/apt cloud-sdk-xenial main

--- a/test-e2e.sh
+++ b/test-e2e.sh
@@ -80,7 +80,8 @@ kubectl version
 
 # Check that all of our tools and samples build
 # Don't build the prow image as it requires docker
-bazel build -- //... -//images/gcloud-bazel:gcloud_install
+bazel build -- //... -//images/gcloud-bazel:gcloud_install \
+  -//images/gcloud-bazel:gcloud_push
 bazel test //...
 
 # Run end-to-end integration testing.

--- a/test-e2e.sh
+++ b/test-e2e.sh
@@ -79,7 +79,8 @@ gcloud version
 kubectl version
 
 # Check that all of our tools and samples build
-bazel build //...
+# Don't build the prow image as it requires docker
+bazel build -- //... -//images/gcloud-bazel:gcloud_install
 bazel test //...
 
 # Run end-to-end integration testing.

--- a/test-e2e.sh
+++ b/test-e2e.sh
@@ -78,11 +78,12 @@ bazel version
 gcloud version
 kubectl version
 
+# Don't build/test the prow image as it requires Docker
+EXCLUDED_TARGETS="-//images/gcloud-bazel:gcloud_install -//images/gcloud-bazel:gcloud_push"
+
 # Check that all of our tools and samples build
-# Don't build the prow image as it requires docker
-bazel build -- //... -//images/gcloud-bazel:gcloud_install \
-  -//images/gcloud-bazel:gcloud_push
-bazel test //...
+bazel build -- //... $EXCLUDED_TARGETS
+bazel test  -- //... $EXCLUDED_TARGETS
 
 # Run end-to-end integration testing.
 # First, GRPC.


### PR DESCRIPTION
For now only added logic to create the container. I haven't uploaded it to GCR because I don't have permissions to access gcr.io/rules-k8s.

The container built by this logic doesn't fully work because gcloud installation has some post processing steps after the extraction of the downloaded tarball. I tried to use bootstrap_image_macro from base_images_docker but ran into some issues. I commented out the call and I explain my issue in comments above the invocation of bootstrap_image_macro. The installation cleanup commands in bootstrap_image_macro show what's needed to fully install gcloud and kubectl in this container.

If this container looks acceptable, the next steps will be to upload this container to GCR and change the prow job definition to use this container. At the same time, the e2e_test.sh will need to be changed to run the post installation steps before running any tests