### PR TITLE
Adding capability to pass in args parameter to kubectl

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,16 @@ Users can "describe" their environment by running:
 bazel run :dev.describe
 ```
 
+### kubectl Arguments Via the Command Line
+
+The apply, create, delete, and describe commands will accept kubectl arguments passed in
+via a cli command. 
+
+To use `--dry-run` for example:
+```shell
+bazel run :dev.delete -- --dry-run
+```
+
 <a name="k8s_object"></a>
 ## k8s_object
 
@@ -492,6 +502,13 @@ A rule for interacting with Kubernetes objects.
       <td>
         <p><code>string, optional</code></p>
         <p>The repository under which to actually publish Docker images.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>kubectl_args</code></td>
+      <td>
+        <p><code>string list, optional</code></p>
+        <p>A list of strings that will be passed into kubectl as additional arguments.</p>
       </td>
     </tr>
   </tbody>

--- a/examples/hellohttp/e2e-test.sh
+++ b/examples/hellohttp/e2e-test.sh
@@ -93,8 +93,40 @@ check_no_images_resolution() {
     echo "${OUTPUT}" | grep "[/]pause[@]"
 }
 
+# e2e test that checks that --v=2 is added to the java kubectl apply command
+# also tests that --help can be passed in as a cli argument
+check_kubectl_args() {
+     
+    # checking that --v=2 is passed in via kubect_arguments in 
+    # the java BUILD file
+    FILE="./bazel-bin/examples/hellohttp/java/staging.apply"
+    echo Checking kubectl args in file: "$FILE"
+    bazel build examples/hellohttp/java:staging.apply
+    if [ ! -f "$FILE" ]; then
+        echo "FAIL: File '$FILE' not found!"
+        exit 1
+    fi
+    if grep -q -- "--v=2" "$FILE"; then
+      echo "PASS: Success, found argument."
+    else
+      echo "FAIL: Did not find --v=2 argument!"
+      exit 1
+    fi
+
+    # passing in --help to kubectl
+    OUTPUT=$(bazel run examples/hellohttp/go:staging.apply -- --help 2>&1)
+    if echo "$OUTPUT" | grep -q Examples:; then
+      echo "PASS: Success, found 'Examples:' argument was passed in"
+      return 0
+    else
+      echo "FAIL: Did not find ouput word 'Examples:' --help was not passed to kubectl"
+      exit 1
+    fi
+}
+
 check_bad_substitution
 check_no_images_resolution
+check_kubectl_args
 
 apply-lb
 

--- a/examples/hellohttp/java/BUILD
+++ b/examples/hellohttp/java/BUILD
@@ -33,4 +33,7 @@ k8s_deploy(
         "hello-http-image": ":server",
     },
     template = "//examples/hellohttp:deployment.json",
+    kubectl_args = [
+     "--v=2",
+    ],
 )

--- a/k8s/apply.sh.tpl
+++ b/k8s/apply.sh.tpl
@@ -24,4 +24,4 @@ function guess_runfiles() {
 RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
 
 PYTHON_RUNFILES=${RUNFILES} %{resolve_script} | \
-  %{kubectl_tool} --cluster="%{cluster}" --context="%{context}" --user="%{user}" %{namespace_arg} apply -f -
+  %{kubectl_tool} --cluster="%{cluster}" --context="%{context}" --user="%{user}" %{namespace_arg} apply %{kubectl_args} -f -

--- a/k8s/apply.sh.tpl
+++ b/k8s/apply.sh.tpl
@@ -24,4 +24,4 @@ function guess_runfiles() {
 RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
 
 PYTHON_RUNFILES=${RUNFILES} %{resolve_script} | \
-  %{kubectl_tool} --cluster="%{cluster}" --context="%{context}" --user="%{user}" %{namespace_arg} apply %{kubectl_args} -f -
+  %{kubectl_tool} --cluster="%{cluster}" --context="%{context}" --user="%{user}" %{namespace_arg} apply %{kubectl_args} $@ -f -

--- a/k8s/create.sh.tpl
+++ b/k8s/create.sh.tpl
@@ -26,4 +26,4 @@ RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
 # TODO(mattmoor): Should we create namespaces that do not exist?
 
 PYTHON_RUNFILES=${RUNFILES} %{resolve_script} | \
-  %{kubectl_tool} --cluster="%{cluster}" --context="%{context}" --user="%{user}" %{namespace_arg} create -f -
+  %{kubectl_tool} --cluster="%{cluster}" --context="%{context}" --user="%{user}" %{namespace_arg} create %{kubectl_args} -f -

--- a/k8s/create.sh.tpl
+++ b/k8s/create.sh.tpl
@@ -26,4 +26,4 @@ RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
 # TODO(mattmoor): Should we create namespaces that do not exist?
 
 PYTHON_RUNFILES=${RUNFILES} %{resolve_script} | \
-  %{kubectl_tool} --cluster="%{cluster}" --context="%{context}" --user="%{user}" %{namespace_arg} create %{kubectl_args} -f -
+  %{kubectl_tool} --cluster="%{cluster}" --context="%{context}" --user="%{user}" %{namespace_arg} create %{kubectl_args} $@ -f -

--- a/k8s/delete.sh.tpl
+++ b/k8s/delete.sh.tpl
@@ -24,4 +24,4 @@ function guess_runfiles() {
 RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
 
 PYTHON_RUNFILES=${RUNFILES} %{reverse_script} | \
-  %{kubectl_tool} --cluster="%{cluster}" --context="%{context}" --user="%{user}" %{namespace_arg} delete %{kubectl_args} --ignore-not-found=true -f -
+  %{kubectl_tool} --cluster="%{cluster}" --context="%{context}" --user="%{user}" %{namespace_arg} delete %{kubectl_args} $@ --ignore-not-found=true -f -

--- a/k8s/delete.sh.tpl
+++ b/k8s/delete.sh.tpl
@@ -24,4 +24,4 @@ function guess_runfiles() {
 RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
 
 PYTHON_RUNFILES=${RUNFILES} %{reverse_script} | \
-  %{kubectl_tool} --cluster="%{cluster}" --context="%{context}" --user="%{user}" %{namespace_arg} delete --ignore-not-found=true -f -
+  %{kubectl_tool} --cluster="%{cluster}" --context="%{context}" --user="%{user}" %{namespace_arg} delete %{kubectl_args} --ignore-not-found=true -f -

--- a/k8s/describe.sh.tpl
+++ b/k8s/describe.sh.tpl
@@ -27,4 +27,4 @@ RESOURCE_NAME=$(kubectl create --dry-run -f "%{unresolved}" -o name | cut -d'"' 
 
 %{kubectl_tool} \
   --cluster="%{cluster}" --context="%{context}" --user="%{user}" \
-  %{namespace_arg} describe "${RESOURCE_NAME}"
+  %{namespace_arg} %{kubectl_args} describe "${RESOURCE_NAME}"

--- a/k8s/describe.sh.tpl
+++ b/k8s/describe.sh.tpl
@@ -27,4 +27,4 @@ RESOURCE_NAME=$(kubectl create --dry-run -f "%{unresolved}" -o name | cut -d'"' 
 
 %{kubectl_tool} \
   --cluster="%{cluster}" --context="%{context}" --user="%{user}" \
-  %{namespace_arg} %{kubectl_args} describe "${RESOURCE_NAME}"
+  %{namespace_arg} describe %{kubectl_args} $@ "${RESOURCE_NAME}"

--- a/k8s/object.bzl
+++ b/k8s/object.bzl
@@ -465,9 +465,8 @@ def k8s_object(name, **kwargs):
         context=kwargs.get("context"),
         user=kwargs.get("user"),
         namespace=kwargs.get("namespace"),
-        **implicit_args
-        visibility=kwargs.get("visibility"),
         kubectl_args=kwargs.get("kubectl_args"),
+        **implicit_args
     )
     _k8s_object_delete(
         name=name + ".delete",
@@ -477,9 +476,8 @@ def k8s_object(name, **kwargs):
         context=kwargs.get("context"),
         user=kwargs.get("user"),
         namespace=kwargs.get("namespace"),
-        **implicit_args
-        visibility=kwargs.get("visibility"),
         kubectl_args=kwargs.get("kubectl_args"),
+        **implicit_args
     )
     _k8s_object_replace(
         name=name + ".replace",
@@ -489,9 +487,8 @@ def k8s_object(name, **kwargs):
         context=kwargs.get("context"),
         user=kwargs.get("user"),
         namespace=kwargs.get("namespace"),
-        **implicit_args
-        visibility=kwargs.get("visibility"),
         kubectl_args=kwargs.get("kubectl_args"),
+        **implicit_args
     )
     _k8s_object_apply(
         name=name + ".apply",
@@ -501,9 +498,8 @@ def k8s_object(name, **kwargs):
         context=kwargs.get("context"),
         user=kwargs.get("user"),
         namespace=kwargs.get("namespace"),
-        **implicit_args
-        visibility=kwargs.get("visibility"),
         kubectl_args=kwargs.get("kubectl_args"),
+        **implicit_args
     )
     if "kind" in kwargs:
       _k8s_object_describe(

--- a/k8s/replace.sh.tpl
+++ b/k8s/replace.sh.tpl
@@ -24,4 +24,4 @@ function guess_runfiles() {
 RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
 
 PYTHON_RUNFILES=${RUNFILES} %{resolve_script} | \
-  %{kubectl_tool} --cluster="%{cluster}" --context="%{context}" --user="%{user}" %{namespace_arg} replace -f -
+  %{kubectl_tool} --cluster="%{cluster}" --context="%{context}" --user="%{user}" %{namespace_arg} replace %{kubectl_args} -f -

--- a/k8s/replace.sh.tpl
+++ b/k8s/replace.sh.tpl
@@ -24,4 +24,4 @@ function guess_runfiles() {
 RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
 
 PYTHON_RUNFILES=${RUNFILES} %{resolve_script} | \
-  %{kubectl_tool} --cluster="%{cluster}" --context="%{context}" --user="%{user}" %{namespace_arg} replace %{kubectl_args} -f -
+  %{kubectl_tool} --cluster="%{cluster}" --context="%{context}" --user="%{user}" %{namespace_arg} replace %{kubectl_args} $@ -f -

--- a/k8s/with-defaults.bzl
+++ b/k8s/with-defaults.bzl
@@ -76,6 +76,10 @@ def _impl(repository_ctx):
     overrides += [_override(repository_ctx.attr.name,
                             "image_chroot", repository_ctx.attr.image_chroot)]
 
+  if repository_ctx.attr.kubectl_args:
+    overrides += [_override(repository_ctx.attr.name,
+                            "kubectl_args", repository_ctx.attr.kubectl_args)]
+
   repository_ctx.file("defaults.bzl", """
 load(
   "@io_bazel_rules_k8s//k8s:object.bzl",
@@ -97,6 +101,7 @@ k8s_defaults = repository_rule(
         "user": attr.string(mandatory = False),
         "namespace": attr.string(mandatory = False),
         "image_chroot": attr.string(mandatory = False),
+        "kubectl_args": attr.string_list(mandatory = False),
     },
     implementation = _impl,
 )


### PR DESCRIPTION
This PR adds a parameter to pass in arguments to kubectl.  For instance
a user can pass in "-v=10 --dry-run=true" to kubectl.  This work is
based off of @omadawn's work.

Once we have the design stabilized I will update the documentation.