### PR TITLE
Fix getting the current cluster name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ k8s_defaults(
   name = "k8s_deploy",
   kind = "deployment",
   # This is the name of the cluster as it appears in:
-  #   kubectl config current-context
+  #   kubectl config view --minify -o=jsonpath='{.contexts[0].context.cluster}'
   cluster = "my-gke-cluster",
 )
 ```
@@ -582,7 +582,7 @@ A repository rule that allows users to alias `k8s_object` with default values.
         <p>The name of the cluster to which <code>create, replace, delete,
            describe</code> should speak.</p>
 	<p>This should match the cluster name as it would appear in
-           <code>kubectl config current-context</code></p>
+           <code>kubectl config view --minify -o=jsonpath='{.contexts[0].context.cluster}'</code></p>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
The current documentation suggests using the current context name (provided by `kubectl config current-context`) as cluster name.

This does not work in configurations in which there is a mismatch between the cluster and context name (_e.g., K8s provided by Docker for Mac).

This pull request fixes this by using the output of `kubectl config view --minify -o=jsonpath='{.contexts[0].context.cluster}'` instead.

Fixes #213 