### PR TITLE
Remove kubectl toolchain execution platform constraint

### DIFF
--- a/toolchains/kubectl/BUILD
+++ b/toolchains/kubectl/BUILD
@@ -28,10 +28,6 @@ kubectl_toolchain(
 
 toolchain(
     name = "kubectl_linux_toolchain",
-    exec_compatible_with = [
-        "@bazel_tools//platforms:linux",
-        "@bazel_tools//platforms:x86_64",
-    ],
     target_compatible_with = [
         "@bazel_tools//platforms:linux",
         "@bazel_tools//platforms:x86_64",
@@ -42,10 +38,6 @@ toolchain(
 
 toolchain(
     name = "kubectl_osx_toolchain",
-    exec_compatible_with = [
-        "@bazel_tools//platforms:osx",
-        "@bazel_tools//platforms:x86_64",
-    ],
     target_compatible_with = [
         "@bazel_tools//platforms:osx",
         "@bazel_tools//platforms:x86_64",
@@ -56,10 +48,6 @@ toolchain(
 
 toolchain(
     name = "kubectl_windows_toolchain",
-    exec_compatible_with = [
-        "@bazel_tools//platforms:windows",
-        "@bazel_tools//platforms:x86_64",
-    ],
     target_compatible_with = [
         "@bazel_tools//platforms:windows",
         "@bazel_tools//platforms:x86_64",


### PR DESCRIPTION
Currently, the toolchains defined for kubectl place a constraint on both the target and execution platform. This results in a toolchain resolution failure when both platforms are different, _e.g.,_ by setting the Bazel `--platform` flag.

This PR removes the execution platform constraint from the kubectl toolchain, which is acceptable as the generated binaries are only expected to run on the target platform.

Fixes #215