### PR TITLE
Arbitrary args for kubectl

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,24 @@ A rule for interacting with Kubernetes objects.
         <p>The repository under which to actually publish Docker images.</p>
       </td>
     </tr>
+    <tr>
+      <td><code>args</code></td>
+      <td>
+        <p><code>string_list, optional</code></p>
+        <p><pre>k8s_deploy(
+    name = "staging",
+    template = "deployment.yaml",
+    args = [
+        "--v=0",
+        "--alsologtostderr=true",
+        "--stderrthreshold=1",
+    ],
+)</pre></p>
+        <p>Additional arguments to pass to the kubectl command at execution.</p>
+        <p>NOTE:</p>
+        <p>Not all options are available for all kubectl commands. To view the list of global options run: <pre>kubectl options</pre></p>
+      </td>
+    </tr>
   </tbody>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -509,6 +509,11 @@ A rule for interacting with Kubernetes objects.
 )</pre></p>
         <p>Additional arguments to pass to the kubectl command at execution.</p>
         <p>NOTE:</p>
+        <p>You can also run something like:</p>
+        <p><pre>bazel run <target> -- <args><pre>
+        <p>to pass additional arguments to the kubectl command in a given bazel
+        invocation.</p>
+        <p>NOTE:</p>
         <p>Not all options are available for all kubectl commands. To view the list of global options run: <pre>kubectl options</pre></p>
       </td>
     </tr>

--- a/examples/hellohttp/e2e-test.sh
+++ b/examples/hellohttp/e2e-test.sh
@@ -114,7 +114,7 @@ check_no_images_resolution() {
     echo "${OUTPUT}" | grep "[/]pause[@]"
 }
 
-# e2e test that checks that args are added to the java kubectl apply command
+# e2e test that checks that args are added to the kubectl apply command
 check_kubectl_args() {
     # Checks that bazel run <some target> does pick up the args attr and
     # passes it to the execution of the template
@@ -122,7 +122,7 @@ check_kubectl_args() {
     # Checks that bazel run <some target> -- <some extra arg> does pass both the
     # args in the attr as well as the <some extra arg> to the execution of the
     # template
-    EXPECT_CONTAINS "$(bazel run examples/hellohttp/java:staging.apply) --v=1" "--v=2 --v=1"
+    EXPECT_CONTAINS "$(bazel run examples/hellohttp/java:staging.apply) -- --v=1" "--v=2 --v=1"
 }
 
 check_bad_substitution

--- a/examples/hellohttp/e2e-test.sh
+++ b/examples/hellohttp/e2e-test.sh
@@ -118,11 +118,11 @@ check_no_images_resolution() {
 check_kubectl_args() {
     # Checks that bazel run <some target> does pick up the args attr and
     # passes it to the execution of the template
-    EXPECT_CONTAINS "$(bazel run examples/hellohttp/java:staging.apply)" "--v=2"
+    EXPECT_CONTAINS "$(bazel run examples/hellohttp/java:staging.apply)" "apply --v=2"
     # Checks that bazel run <some target> -- <some extra arg> does pass both the
     # args in the attr as well as the <some extra arg> to the execution of the
     # template
-    EXPECT_CONTAINS "$(bazel run examples/hellohttp/java:staging.apply) -- --v=1" "--v=2 --v=1"
+    EXPECT_CONTAINS "$(bazel run examples/hellohttp/java:staging.apply) -- --v=1" "apply --v=2 --v=1"
 }
 
 check_bad_substitution

--- a/examples/hellohttp/e2e-test.sh
+++ b/examples/hellohttp/e2e-test.sh
@@ -122,7 +122,7 @@ check_kubectl_args() {
     # Checks that bazel run <some target> -- <some extra arg> does pass both the
     # args in the attr as well as the <some extra arg> to the execution of the
     # template
-    EXPECT_CONTAINS "$(bazel run examples/hellohttp/java:staging.apply) -- --v=1" "apply --v=2 --v=1"
+    EXPECT_CONTAINS "$(bazel run examples/hellohttp/java:staging.apply -- --v=1)" "apply --v=2 --v=1"
 }
 
 check_bad_substitution

--- a/examples/hellohttp/e2e-test.sh
+++ b/examples/hellohttp/e2e-test.sh
@@ -114,9 +114,14 @@ check_no_images_resolution() {
     echo "${OUTPUT}" | grep "[/]pause[@]"
 }
 
-# e2e test that checks that --v=2 is added to the java kubectl apply command
+# e2e test that checks that args are added to the java kubectl apply command
 check_kubectl_args() {
+    # Checks that bazel run <some target> does pick up the args attr and
+    # passes it to the execution of the template
     EXPECT_CONTAINS "$(bazel run examples/hellohttp/java:staging.apply)" "--v=2"
+    # Checks that bazel run <some target> -- <some extra arg> does pass both the
+    # args in the attr as well as the <some extra arg> to the execution of the
+    # template
     EXPECT_CONTAINS "$(bazel run examples/hellohttp/java:staging.apply) --v=1" "--v=2 --v=1"
 }
 

--- a/examples/hellohttp/java/BUILD
+++ b/examples/hellohttp/java/BUILD
@@ -29,6 +29,9 @@ load("@k8s_deploy//:defaults.bzl", "k8s_deploy")
 
 k8s_deploy(
     name = "staging",
+    args = [
+        "--v=2",
+    ],
     images = {
         "hello-http-image": ":server",
     },

--- a/k8s/apply.sh.tpl
+++ b/k8s/apply.sh.tpl
@@ -24,4 +24,9 @@ function guess_runfiles() {
 RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
 
 PYTHON_RUNFILES=${RUNFILES} %{resolve_script} | \
-  %{kubectl_tool} --cluster="%{cluster}" --context="%{context}" --user="%{user}" %{namespace_arg} apply $@ -f -
+  ( set -x ;  %{kubectl_tool} --cluster="%{cluster}" --context="%{context}" --user="%{user}" %{namespace_arg} apply $@ -f - )
+
+if [ $? -eq 0 ] ; then
+    echo "apply failed"
+    exit 1
+fi

--- a/k8s/apply.sh.tpl
+++ b/k8s/apply.sh.tpl
@@ -24,4 +24,4 @@ function guess_runfiles() {
 RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
 
 PYTHON_RUNFILES=${RUNFILES} %{resolve_script} | \
-  %{kubectl_tool} --cluster="%{cluster}" --context="%{context}" --user="%{user}" %{namespace_arg} apply -f -
+  %{kubectl_tool} --cluster="%{cluster}" --context="%{context}" --user="%{user}" %{namespace_arg} apply $@ -f -

--- a/k8s/apply.sh.tpl
+++ b/k8s/apply.sh.tpl
@@ -21,7 +21,9 @@ function guess_runfiles() {
     popd > /dev/null 2>&1
 }
 
+function exe() { echo "\$ ${@/eval/}" ; "$@" ; }
+
 RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
 
 PYTHON_RUNFILES=${RUNFILES} %{resolve_script} | \
-  ( set -x ;  %{kubectl_tool} --cluster="%{cluster}" --context="%{context}" --user="%{user}" %{namespace_arg} apply $@ -f - )
+  exe  %{kubectl_tool} --cluster="%{cluster}" --context="%{context}" --user="%{user}" %{namespace_arg} apply $@ -f -

--- a/k8s/apply.sh.tpl
+++ b/k8s/apply.sh.tpl
@@ -25,8 +25,3 @@ RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
 
 PYTHON_RUNFILES=${RUNFILES} %{resolve_script} | \
   ( set -x ;  %{kubectl_tool} --cluster="%{cluster}" --context="%{context}" --user="%{user}" %{namespace_arg} apply $@ -f - )
-
-if [ $? -eq 0 ] ; then
-    echo "apply failed"
-    exit 1
-fi

--- a/k8s/create.sh.tpl
+++ b/k8s/create.sh.tpl
@@ -26,4 +26,4 @@ RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
 # TODO(mattmoor): Should we create namespaces that do not exist?
 
 PYTHON_RUNFILES=${RUNFILES} %{resolve_script} | \
-  %{kubectl_tool} --cluster="%{cluster}" --context="%{context}" --user="%{user}" %{namespace_arg} create -f -
+  %{kubectl_tool} --cluster="%{cluster}" --context="%{context}" --user="%{user}" %{namespace_arg} create $@ -f -

--- a/k8s/create.sh.tpl
+++ b/k8s/create.sh.tpl
@@ -21,9 +21,11 @@ function guess_runfiles() {
     popd > /dev/null 2>&1
 }
 
+function exe() { echo "\$ ${@/eval/}" ; "$@" ; }
+
 RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
 
 # TODO(mattmoor): Should we create namespaces that do not exist?
 
 PYTHON_RUNFILES=${RUNFILES} %{resolve_script} | \
-  ( set -x ; %{kubectl_tool} --cluster="%{cluster}" --context="%{context}" --user="%{user}" %{namespace_arg} create $@ -f - )
+  exe %{kubectl_tool} --cluster="%{cluster}" --context="%{context}" --user="%{user}" %{namespace_arg} create $@ -f -

--- a/k8s/create.sh.tpl
+++ b/k8s/create.sh.tpl
@@ -26,4 +26,9 @@ RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
 # TODO(mattmoor): Should we create namespaces that do not exist?
 
 PYTHON_RUNFILES=${RUNFILES} %{resolve_script} | \
-  %{kubectl_tool} --cluster="%{cluster}" --context="%{context}" --user="%{user}" %{namespace_arg} create $@ -f -
+  ( set -x ; %{kubectl_tool} --cluster="%{cluster}" --context="%{context}" --user="%{user}" %{namespace_arg} create $@ -f - )
+
+if [ $? -eq 0 ] ; then
+    echo "create failed"
+    exit 1
+fi

--- a/k8s/create.sh.tpl
+++ b/k8s/create.sh.tpl
@@ -27,8 +27,3 @@ RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
 
 PYTHON_RUNFILES=${RUNFILES} %{resolve_script} | \
   ( set -x ; %{kubectl_tool} --cluster="%{cluster}" --context="%{context}" --user="%{user}" %{namespace_arg} create $@ -f - )
-
-if [ $? -eq 0 ] ; then
-    echo "create failed"
-    exit 1
-fi

--- a/k8s/delete.sh.tpl
+++ b/k8s/delete.sh.tpl
@@ -21,7 +21,9 @@ function guess_runfiles() {
     popd > /dev/null 2>&1
 }
 
+function exe() { echo "\$ ${@/eval/}" ; "$@" ; }
+
 RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
 
 PYTHON_RUNFILES=${RUNFILES} %{reverse_script} | \
-  ( set -x ; %{kubectl_tool} --cluster="%{cluster}" --context="%{context}" --user="%{user}" %{namespace_arg} delete $@ --ignore-not-found=true -f - )
+  exe %{kubectl_tool} --cluster="%{cluster}" --context="%{context}" --user="%{user}" %{namespace_arg} delete $@ --ignore-not-found=true -f -

--- a/k8s/delete.sh.tpl
+++ b/k8s/delete.sh.tpl
@@ -25,8 +25,3 @@ RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
 
 PYTHON_RUNFILES=${RUNFILES} %{reverse_script} | \
   ( set -x ; %{kubectl_tool} --cluster="%{cluster}" --context="%{context}" --user="%{user}" %{namespace_arg} delete $@ --ignore-not-found=true -f - )
-
-if [ $? -eq 0 ] ; then
-    echo "delete failed"
-    exit 1
-fi

--- a/k8s/delete.sh.tpl
+++ b/k8s/delete.sh.tpl
@@ -24,4 +24,4 @@ function guess_runfiles() {
 RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
 
 PYTHON_RUNFILES=${RUNFILES} %{reverse_script} | \
-  %{kubectl_tool} --cluster="%{cluster}" --context="%{context}" --user="%{user}" %{namespace_arg} delete --ignore-not-found=true -f -
+  %{kubectl_tool} --cluster="%{cluster}" --context="%{context}" --user="%{user}" %{namespace_arg} delete $@ --ignore-not-found=true -f -

--- a/k8s/delete.sh.tpl
+++ b/k8s/delete.sh.tpl
@@ -24,4 +24,9 @@ function guess_runfiles() {
 RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
 
 PYTHON_RUNFILES=${RUNFILES} %{reverse_script} | \
-  %{kubectl_tool} --cluster="%{cluster}" --context="%{context}" --user="%{user}" %{namespace_arg} delete $@ --ignore-not-found=true -f -
+  ( set -x ; %{kubectl_tool} --cluster="%{cluster}" --context="%{context}" --user="%{user}" %{namespace_arg} delete $@ --ignore-not-found=true -f - )
+
+if [ $? -eq 0 ] ; then
+    echo "delete failed"
+    exit 1
+fi

--- a/k8s/describe.sh.tpl
+++ b/k8s/describe.sh.tpl
@@ -25,6 +25,11 @@ RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
 
 RESOURCE_NAME=$(kubectl create --dry-run -f "%{unresolved}" -o name | cut -d'"' -f 2)
 
-%{kubectl_tool} \
+( set -x ; %{kubectl_tool} \
   --cluster="%{cluster}" --context="%{context}" --user="%{user}" \
-  %{namespace_arg} describe $@ "${RESOURCE_NAME}"
+  %{namespace_arg} describe $@ "${RESOURCE_NAME}" )
+
+if [ $? -eq 0 ] ; then
+    echo "describe failed"
+    exit 1
+fi

--- a/k8s/describe.sh.tpl
+++ b/k8s/describe.sh.tpl
@@ -21,10 +21,12 @@ function guess_runfiles() {
     popd > /dev/null 2>&1
 }
 
+function exe() { echo "\$ ${@/eval/}" ; "$@" ; }
+
 RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
 
 RESOURCE_NAME=$(kubectl create --dry-run -f "%{unresolved}" -o name | cut -d'"' -f 2)
 
-( set -x ; %{kubectl_tool} \
+exe %{kubectl_tool} \
   --cluster="%{cluster}" --context="%{context}" --user="%{user}" \
-  %{namespace_arg} describe $@ "${RESOURCE_NAME}" )
+  %{namespace_arg} describe $@ "${RESOURCE_NAME}"

--- a/k8s/describe.sh.tpl
+++ b/k8s/describe.sh.tpl
@@ -27,4 +27,4 @@ RESOURCE_NAME=$(kubectl create --dry-run -f "%{unresolved}" -o name | cut -d'"' 
 
 %{kubectl_tool} \
   --cluster="%{cluster}" --context="%{context}" --user="%{user}" \
-  %{namespace_arg} describe "${RESOURCE_NAME}"
+  %{namespace_arg} describe $@ "${RESOURCE_NAME}"

--- a/k8s/describe.sh.tpl
+++ b/k8s/describe.sh.tpl
@@ -28,8 +28,3 @@ RESOURCE_NAME=$(kubectl create --dry-run -f "%{unresolved}" -o name | cut -d'"' 
 ( set -x ; %{kubectl_tool} \
   --cluster="%{cluster}" --context="%{context}" --user="%{user}" \
   %{namespace_arg} describe $@ "${RESOURCE_NAME}" )
-
-if [ $? -eq 0 ] ; then
-    echo "describe failed"
-    exit 1
-fi

--- a/k8s/object.bzl
+++ b/k8s/object.bzl
@@ -454,6 +454,7 @@ def k8s_object(name, **kwargs):
         context=kwargs.get("context"),
         user=kwargs.get("user"),
         namespace=kwargs.get("namespace"),
+        args=kwargs.get("args"),
         **implicit_args
     )
     _k8s_object_delete(
@@ -464,6 +465,7 @@ def k8s_object(name, **kwargs):
         context=kwargs.get("context"),
         user=kwargs.get("user"),
         namespace=kwargs.get("namespace"),
+        args=kwargs.get("args"),
         **implicit_args
     )
     _k8s_object_replace(
@@ -474,6 +476,7 @@ def k8s_object(name, **kwargs):
         context=kwargs.get("context"),
         user=kwargs.get("user"),
         namespace=kwargs.get("namespace"),
+        args=kwargs.get("args"),
         **implicit_args
     )
     _k8s_object_apply(
@@ -484,6 +487,7 @@ def k8s_object(name, **kwargs):
         context=kwargs.get("context"),
         user=kwargs.get("user"),
         namespace=kwargs.get("namespace"),
+        args=kwargs.get("args"),
         **implicit_args
     )
     if "kind" in kwargs:
@@ -495,5 +499,6 @@ def k8s_object(name, **kwargs):
         context=kwargs.get("context"),
         user=kwargs.get("user"),
         namespace=kwargs.get("namespace"),
+        args=kwargs.get("args"),
         **implicit_args
     )

--- a/k8s/replace.sh.tpl
+++ b/k8s/replace.sh.tpl
@@ -24,4 +24,9 @@ function guess_runfiles() {
 RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
 
 PYTHON_RUNFILES=${RUNFILES} %{resolve_script} | \
-  %{kubectl_tool} --cluster="%{cluster}" --context="%{context}" --user="%{user}" %{namespace_arg} replace $@ -f -
+  ( set -x ; %{kubectl_tool} --cluster="%{cluster}" --context="%{context}" --user="%{user}" %{namespace_arg} replace $@ -f - )
+
+if [ $? -eq 0 ] ; then
+    echo "replace failed"
+    exit 1
+fi

--- a/k8s/replace.sh.tpl
+++ b/k8s/replace.sh.tpl
@@ -21,7 +21,9 @@ function guess_runfiles() {
     popd > /dev/null 2>&1
 }
 
+function exe() { echo "\$ ${@/eval/}" ; "$@" ; }
+
 RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
 
 PYTHON_RUNFILES=${RUNFILES} %{resolve_script} | \
-  ( set -x ; %{kubectl_tool} --cluster="%{cluster}" --context="%{context}" --user="%{user}" %{namespace_arg} replace $@ -f - )
+  exe %{kubectl_tool} --cluster="%{cluster}" --context="%{context}" --user="%{user}" %{namespace_arg} replace $@ -f -

--- a/k8s/replace.sh.tpl
+++ b/k8s/replace.sh.tpl
@@ -24,4 +24,4 @@ function guess_runfiles() {
 RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
 
 PYTHON_RUNFILES=${RUNFILES} %{resolve_script} | \
-  %{kubectl_tool} --cluster="%{cluster}" --context="%{context}" --user="%{user}" %{namespace_arg} replace -f -
+  %{kubectl_tool} --cluster="%{cluster}" --context="%{context}" --user="%{user}" %{namespace_arg} replace $@ -f -

--- a/k8s/replace.sh.tpl
+++ b/k8s/replace.sh.tpl
@@ -25,8 +25,3 @@ RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
 
 PYTHON_RUNFILES=${RUNFILES} %{resolve_script} | \
   ( set -x ; %{kubectl_tool} --cluster="%{cluster}" --context="%{context}" --user="%{user}" %{namespace_arg} replace $@ -f - )
-
-if [ $? -eq 0 ] ; then
-    echo "replace failed"
-    exit 1
-fi

--- a/toolchains/kubectl/BUILD
+++ b/toolchains/kubectl/BUILD
@@ -28,10 +28,6 @@ kubectl_toolchain(
 
 toolchain(
     name = "kubectl_linux_toolchain",
-    exec_compatible_with = [
-        "@bazel_tools//platforms:linux",
-        "@bazel_tools//platforms:x86_64",
-    ],
     target_compatible_with = [
         "@bazel_tools//platforms:linux",
         "@bazel_tools//platforms:x86_64",
@@ -42,10 +38,6 @@ toolchain(
 
 toolchain(
     name = "kubectl_osx_toolchain",
-    exec_compatible_with = [
-        "@bazel_tools//platforms:osx",
-        "@bazel_tools//platforms:x86_64",
-    ],
     target_compatible_with = [
         "@bazel_tools//platforms:osx",
         "@bazel_tools//platforms:x86_64",
@@ -56,10 +48,6 @@ toolchain(
 
 toolchain(
     name = "kubectl_windows_toolchain",
-    exec_compatible_with = [
-        "@bazel_tools//platforms:windows",
-        "@bazel_tools//platforms:x86_64",
-    ],
     target_compatible_with = [
         "@bazel_tools//platforms:windows",
         "@bazel_tools//platforms:x86_64",


### PR DESCRIPTION
Trying this PR to replace all other PRs discussed in https://github.com/bazelbuild/rules_k8s/issues/209.
With this PR:
- users can add args (string list) to their k8s_deploy object
- users can use bazel run <target> -- <extra args>
- modified templates so the kubectl command is printed out when running bazel run <target>, useful for validation in e2e tests

Hope this satisfies everyone's needs.
fyi @chrislovecnm @Globegitter @omadawn 
