### PR TITLE
Update toolchain docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,42 @@ load("@io_bazel_rules_k8s//k8s:k8s.bzl", "k8s_repositories")
 k8s_repositories()
 ```
 
+*New: Starting https://github.com/bazelbuild/rules_k8s/commit/ff2cbf09ae1f0a9c7ebdfc1fa337044158a7f57b
+you need to configure your WORKSPACE properly for the `kubectl` tool.
+See more below in * [Dependencies](#Dependencies)
+
+To build the `kubectl` tool from source (default) you will also
+need to add to your `WORKSPACE` file the following dependency:
+
+```python
+ http_archive(
+    name = "io_bazel_rules_go",
+    urls = ["https://github.com/bazelbuild/rules_go/archive/0.16.1.tar.gz"],
+    sha256 = "ced2749527318abeddd9d91f5e1555ed86e2b6bfd08677b750396e0ec5462bec",
+    strip_prefix = "rules_go-0.16.1",
+ )
+```
+
+To detect the path to the `kubectl` tool you will
+need to add to your `WORKSPACE` file the `kubectl_configure` target before the
+`k8s_repositories` target:
+
+```python
+load("//toolchains/kubectl:kubectl_configure.bzl", "kubectl_configure")
+
+kubectl_configure(name = "k8s_config")
+
+load("@io_bazel_rules_k8s//k8s:k8s.bzl", "k8s_repositories")
+
+k8s_repositories()
+```
+
+Note if no `kubectl` tool is found trying to execute bazel run for any targets
+will fail.
+
+*NOTE: we are currently experimenting with toolchain features in these rules
+so there will be changes upcoming to how this configuration is performed*
+
 ## Kubernetes Authentication
 
 As is somewhat standard for Bazel, the expectation is that the
@@ -56,6 +92,9 @@ you might interact with.
 
 For more information on how to configure `kubectl` authentication, see the
 Kubernetes [documentation](https://kubernetes.io/docs/admin/authentication/).
+
+*NOTE: we are currently experimenting with toolchain features in these rules
+so there will be changes upcoming to how this configuration is performed*
 
 ### Container Engine Authentication
 
@@ -66,13 +105,23 @@ for setting up authentication:
 gcloud container clusters get-credentials <CLUSTER NAME>
 ```
 
+*NOTE: we are currently experimenting with toolchain features in these rules
+so there will be changes upcoming to how this configuration is performed*
+
 ## Dependencies
 
-The rules will require the `kubectl` tool when executing the `run` action from
-bazel. The `kubectl` tool is configured via a toolchain rule. Read more about
+*New: Starting https://github.com/bazelbuild/rules_k8s/commit/ff2cbf09ae1f0a9c7ebdfc1fa337044158a7f57b
+these rules can either build the `kubectl` tool (default) or use a
+pre-installed `kubectl` tool when executing the `run` action from
+bazel.*
+
+The `kubectl` tool is configured via a toolchain rule. Read more about
 the kubectl toolchain [here](toolchains/kubectl#kubectl-toolchain).
 
-If GKE is used, also the `gcloud` sdk need to be installed.
+If GKE is used, also the `gcloud` sdk needs to be installed.
+
+*NOTE: we are currently experimenting with toolchain features in these rules
+so there will be changes upcoming to how this configuration is performed*
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,12 @@ k8s_repositories()
 
 *New: Starting https://github.com/bazelbuild/rules_k8s/commit/ff2cbf09ae1f0a9c7ebdfc1fa337044158a7f57b
 you need to configure your WORKSPACE properly for the `kubectl` tool.
-See more below in [Dependencies](#Dependencies)*
+See more details below in [Dependencies](#Dependencies)*
+
+To properly configure these rules you also need to select either to:
+
+1. Build the `kubectl` tool from source (default).
+2. Detect the path to the `kubectl` tool.
 
 To build the `kubectl` tool from source (default) you will also
 need to add to your `WORKSPACE` file the following dependency:

--- a/README.md
+++ b/README.md
@@ -77,8 +77,9 @@ so there will be changes upcoming to how this configuration is performed*
 *New: Starting https://github.com/bazelbuild/rules_k8s/commit/ff2cbf09ae1f0a9c7ebdfc1fa337044158a7f57b*
 
 These rules can either use a pre-installed `kubectl` tool (default) or
-build the `kubectl` tool. The `kubectl` tool is used when executing the
-`run` action from bazel.
+build the `kubectl` tool from sources.
+
+The `kubectl` tool is used when executing the `run` action from bazel.
 
 The `kubectl` tool is configured via a toolchain rule. Read more about
 the kubectl toolchain [here](toolchains/kubectl#kubectl-toolchain).

--- a/README.md
+++ b/README.md
@@ -48,47 +48,6 @@ load("@io_bazel_rules_k8s//k8s:k8s.bzl", "k8s_repositories")
 k8s_repositories()
 ```
 
-*New: Starting https://github.com/bazelbuild/rules_k8s/commit/ff2cbf09ae1f0a9c7ebdfc1fa337044158a7f57b
-you need to configure your WORKSPACE properly for the `kubectl` tool.
-See more details below in [Dependencies](#Dependencies)*
-
-To properly configure these rules you also need to select either to:
-
-1. Build the `kubectl` tool from source (default).
-2. Detect the path to the `kubectl` tool.
-
-To build the `kubectl` tool from source (default) you will also
-need to add to your `WORKSPACE` file the following dependency:
-
-```python
- http_archive(
-    name = "io_bazel_rules_go",
-    urls = ["https://github.com/bazelbuild/rules_go/archive/0.16.1.tar.gz"],
-    sha256 = "ced2749527318abeddd9d91f5e1555ed86e2b6bfd08677b750396e0ec5462bec",
-    strip_prefix = "rules_go-0.16.1",
- )
-```
-
-To detect the path to the `kubectl` tool you will
-need to add to your `WORKSPACE` file the `kubectl_configure` target before the
-`k8s_repositories` target:
-
-```python
-load("//toolchains/kubectl:kubectl_configure.bzl", "kubectl_configure")
-
-kubectl_configure(name = "k8s_config")
-
-load("@io_bazel_rules_k8s//k8s:k8s.bzl", "k8s_repositories")
-
-k8s_repositories()
-```
-
-Note if no `kubectl` tool is found trying to execute bazel run for any targets
-will fail.
-
-*NOTE: we are currently experimenting with toolchain features in these rules
-so there will be changes upcoming to how this configuration is performed*
-
 ## Kubernetes Authentication
 
 As is somewhat standard for Bazel, the expectation is that the
@@ -115,10 +74,11 @@ so there will be changes upcoming to how this configuration is performed*
 
 ## Dependencies
 
-*New: Starting https://github.com/bazelbuild/rules_k8s/commit/ff2cbf09ae1f0a9c7ebdfc1fa337044158a7f57b
-these rules can either build the `kubectl` tool (default) or use a
-pre-installed `kubectl` tool when executing the `run` action from
-bazel.*
+*New: Starting https://github.com/bazelbuild/rules_k8s/commit/ff2cbf09ae1f0a9c7ebdfc1fa337044158a7f57b*
+
+These rules can either use a pre-installed `kubectl` tool (default) or
+build the `kubectl` tool. The `kubectl` tool is used when executing the
+`run` action from bazel.
 
 The `kubectl` tool is configured via a toolchain rule. Read more about
 the kubectl toolchain [here](toolchains/kubectl#kubectl-toolchain).

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ k8s_repositories()
 
 *New: Starting https://github.com/bazelbuild/rules_k8s/commit/ff2cbf09ae1f0a9c7ebdfc1fa337044158a7f57b
 you need to configure your WORKSPACE properly for the `kubectl` tool.
-See more below in * [Dependencies](#Dependencies)
+See more below in [Dependencies](#Dependencies)*
 
 To build the `kubectl` tool from source (default) you will also
 need to add to your `WORKSPACE` file the following dependency:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -60,7 +60,7 @@ docker_repositories()
 
 load("//k8s:k8s.bzl", "k8s_repositories", "k8s_defaults")
 
-k8s_repositories(build_kubectl_srcs = True)
+k8s_repositories(build_kubectl_srcs = False)
 
 _CLUSTER = "gke_rules-k8s_us-central1-f_testing"
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -60,7 +60,7 @@ docker_repositories()
 
 load("//k8s:k8s.bzl", "k8s_repositories", "k8s_defaults")
 
-k8s_repositories()
+k8s_repositories(build_kubectl_srcs = True)
 
 _CLUSTER = "gke_rules-k8s_us-central1-f_testing"
 

--- a/k8s/k8s.bzl
+++ b/k8s/k8s.bzl
@@ -12,38 +12,46 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Rules for manipulation of K8s constructs."""
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load(":with-defaults.bzl", "k8s_defaults")
 load("//toolchains/kubectl:kubectl_configure.bzl", "kubectl_configure")
 
-def k8s_repositories():
-  """Download dependencies of k8s rules."""
+def k8s_repositories(build_kubectl_srcs = False):
+    """Download dependencies of k8s rules."""
 
-  # Used by utilities for roundtripping yaml.
-  http_archive(
-    name = "yaml",
-    build_file_content = """
+    # Used by utilities for roundtripping yaml.
+    http_archive(
+        name = "yaml",
+        build_file_content = """
 py_library(
     name = "yaml",
     srcs = glob(["*.py"]),
     visibility = ["//visibility:public"],
 )""",
-    sha256 = "592766c6303207a20efc445587778322d7f73b161bd994f227adaa341ba212ab",
-    urls = [("https://pypi.python.org/packages/4a/85/" +
-           "db5a2df477072b2902b0eb892feb37d88ac635d36245a72a6a69b23b383a" +
-           "/PyYAML-3.12.tar.gz")],
-    strip_prefix = "PyYAML-3.12/lib/yaml",
-  )
+        sha256 = "592766c6303207a20efc445587778322d7f73b161bd994f227adaa341ba212ab",
+        urls = [("https://pypi.python.org/packages/4a/85/" +
+                 "db5a2df477072b2902b0eb892feb37d88ac635d36245a72a6a69b23b383a" +
+                 "/PyYAML-3.12.tar.gz")],
+        strip_prefix = "PyYAML-3.12/lib/yaml",
+    )
 
-  # Register the default kubectl toolchain targets for supported platforms
-  # note these work with the autoconfigured toolchain
-  native.register_toolchains(
-    "@io_bazel_rules_k8s//toolchains/kubectl:kubectl_linux_toolchain",
-    "@io_bazel_rules_k8s//toolchains/kubectl:kubectl_osx_toolchain",
-    "@io_bazel_rules_k8s//toolchains/kubectl:kubectl_windows_toolchain",
-  )
+    # Register the default kubectl toolchain targets for supported platforms
+    # note these work with the autoconfigured toolchain
+    native.register_toolchains(
+        "@io_bazel_rules_k8s//toolchains/kubectl:kubectl_linux_toolchain",
+        "@io_bazel_rules_k8s//toolchains/kubectl:kubectl_osx_toolchain",
+        "@io_bazel_rules_k8s//toolchains/kubectl:kubectl_windows_toolchain",
+    )
 
-  excludes = native.existing_rules().keys()
-  if "k8s_config" not in excludes:
-    # WORKSPACE target to configure the kubectl tool
-    kubectl_configure(name = "k8s_config", build_srcs = True)
+    excludes = native.existing_rules().keys()
+    if "k8s_config" not in excludes:
+        # WORKSPACE target to configure the kubectl tool
+        kubectl_configure(name = "k8s_config", build_srcs = build_kubectl_srcs)
+        if build_kubectl_srcs and "io_bazel_rules_go" not in excludes:
+            http_archive(
+                name = "io_bazel_rules_go",
+                urls = ["https://github.com/bazelbuild/rules_go/archive/0.16.1.tar.gz"],
+                sha256 = "ced2749527318abeddd9d91f5e1555ed86e2b6bfd08677b750396e0ec5462bec",
+                strip_prefix = "rules_go-0.16.1",
+            )

--- a/k8s/object.bzl
+++ b/k8s/object.bzl
@@ -173,15 +173,14 @@ def _common_impl(ctx):
         namespace_arg = "--namespace=\"" + namespace_arg + "\""
 
     kubectl_tool_info = ctx.toolchains["@io_bazel_rules_k8s//toolchains/kubectl:toolchain_type"].kubectlinfo
-    if not kubectl_tool_info.tool_path and not kubectl_tool_info.tool_target:
-        # If tool_path is None and tool_target is None then there is no local
+    if kubectl_tool_info.tool_path == "" and not kubectl_tool_info.tool_target:
+        # If tool_path is empty and tool_target is None then there is no local
         # kubectl tool, we will just print a nice error message if the user
         # attempts to do bazel run
         ctx.actions.write(
-            content = "echo kubectl toolchain was not properly configured so this target cannot be executed",
+            content = ("echo kubectl toolchain was not properly configured so %s cannot be executed." % ctx.attr.name),
             output = ctx.outputs.executable,
         )
-
     else:
         kubectl_tool = kubectl_tool_info.tool_path
         if kubectl_tool_info.tool_target:

--- a/k8s/object.bzl
+++ b/k8s/object.bzl
@@ -173,39 +173,50 @@ def _common_impl(ctx):
         namespace_arg = "--namespace=\"" + namespace_arg + "\""
 
     kubectl_tool_info = ctx.toolchains["@io_bazel_rules_k8s//toolchains/kubectl:toolchain_type"].kubectlinfo
-    kubectl_tool = kubectl_tool_info.tool_path
-    if not kubectl_tool_info.tool_path:
-        kubectl_tool = _runfiles(ctx, kubectl_tool_info.tool_target.files.to_list()[0])
-        files += kubectl_tool_info.tool_target.files.to_list()
+    if not kubectl_tool_info.tool_path and not kubectl_tool_info.tool_target:
+        # If tool_path is None and tool_target is None then there is no local
+        # kubectl tool, we will just print a nice error message if the user
+        # attempts to do bazel run
+        ctx.actions.write(
+            content = "echo kubectl toolchain was not properly configured so this target cannot be executed",
+            output = ctx.outputs.executable,
+        )
 
-    substitutions = {
-        "%{kubectl_tool}": kubectl_tool,
-        "%{cluster}": cluster_arg,
-        "%{context}": context_arg,
-        "%{user}": user_arg,
-        "%{namespace_arg}": namespace_arg,
-        "%{kind}": ctx.attr.kind,
-    }
+    else:
+        kubectl_tool = kubectl_tool_info.tool_path
+        if kubectl_tool_info.tool_target:
+            kubectl_tool = _runfiles(ctx, kubectl_tool_info.tool_target.files.to_list()[0])
+            files += kubectl_tool_info.tool_target.files.to_list()
 
-    if hasattr(ctx.executable, "resolved"):
-        substitutions["%{resolve_script}"] = _runfiles(ctx, ctx.executable.resolved)
-        files += [ctx.executable.resolved]
-        files += list(ctx.attr.resolved.default_runfiles.files)
+        substitutions = {
+            "%{kubectl_tool}": kubectl_tool,
+            "%{cluster}": cluster_arg,
+            "%{context}": context_arg,
+            "%{user}": user_arg,
+            "%{namespace_arg}": namespace_arg,
+            "%{kind}": ctx.attr.kind,
+        }
 
-    if hasattr(ctx.executable, "reversed"):
-        substitutions["%{reverse_script}"] = _runfiles(ctx, ctx.executable.reversed)
-        files += [ctx.executable.reversed]
-        files += list(ctx.attr.reversed.default_runfiles.files)
+        if hasattr(ctx.executable, "resolved"):
+            substitutions["%{resolve_script}"] = _runfiles(ctx, ctx.executable.resolved)
+            files += [ctx.executable.resolved]
+            files += list(ctx.attr.resolved.default_runfiles.files)
 
-    if hasattr(ctx.files, "unresolved"):
-        substitutions["%{unresolved}"] = _runfiles(ctx, ctx.file.unresolved)
-        files += ctx.files.unresolved
+        if hasattr(ctx.executable, "reversed"):
+            substitutions["%{reverse_script}"] = _runfiles(ctx, ctx.executable.reversed)
+            files += [ctx.executable.reversed]
+            files += list(ctx.attr.reversed.default_runfiles.files)
 
-    ctx.actions.expand_template(
-        template = ctx.file._template,
-        substitutions = substitutions,
-        output = ctx.outputs.executable,
-    )
+        if hasattr(ctx.files, "unresolved"):
+            substitutions["%{unresolved}"] = _runfiles(ctx, ctx.file.unresolved)
+            files += ctx.files.unresolved
+
+        ctx.actions.expand_template(
+            template = ctx.file._template,
+            substitutions = substitutions,
+            output = ctx.outputs.executable,
+        )
+
     return struct(runfiles = ctx.runfiles(files = files))
 
 _common_attrs = {

--- a/toolchains/kubectl/README.md
+++ b/toolchains/kubectl/README.md
@@ -7,7 +7,7 @@ rule. At the moment, the tool's configuration does one of the following:
 1. Detect the path to the `kubectl` tool (default).
 2. Build the `kubectl` tool from source.
 
-If you want to use the default (build the `kubectl` tool from source) you will
+If you want to build the `kubectl` tool from source you will
 need to add to your `WORKSPACE` file the following lines (note the extra arg
 in the call to `k8s_repositories()`):
 

--- a/toolchains/kubectl/README.md
+++ b/toolchains/kubectl/README.md
@@ -2,13 +2,46 @@
 
 ## Overview
 This section describes how the `kubectl` tool is configured using a toolchain
-rule. At the moment, the tool's configuration only detects the path to the
-`kubectl` tool.
+rule. At the moment, the tool's configuration does one of the following:
+
+1. Build the `kubectl` tool from source (default).
+2. Detect the path to the `kubectl` tool.
+
+If you want to use the default (build the `kubectl` tool from source) you will
+need to add to your `WORKSPACE` file the following dependency:
+
+```python
+ http_archive(
+    name = "io_bazel_rules_go",
+    urls = ["https://github.com/bazelbuild/rules_go/archive/0.16.1.tar.gz"],
+    sha256 = "ced2749527318abeddd9d91f5e1555ed86e2b6bfd08677b750396e0ec5462bec",
+    strip_prefix = "rules_go-0.16.1",
+ )
+```
+
+If you want the rules to detect the path to the `kubectl` tool you will
+need to add to your `WORKSPACE` file the `kubectl_configure` target before the
+`k8s_repositories` target:
+
+```python
+load("//toolchains/kubectl:kubectl_configure.bzl", "kubectl_configure")
+
+kubectl_configure(name = "k8s_config")
+
+load("@io_bazel_rules_k8s//k8s:k8s.bzl", "k8s_repositories")
+
+k8s_repositories()
+```
+
+*NOTE: we are currently experimenting with toolchain features in these rules
+so there will be changes upcoming to how this configuration is performed*
+
+## Using the kubectl toolchain
 
 The information below will be helpful if:
 
-1. You wish to write a new Bazel rule that uses the `kubectl` tool.
-2. You wish to extend rules from this repository that are using the kubectl
+1. You want to write a new Bazel rule that uses the `kubectl` tool.
+2. You want to extend rules from this repository that are using the kubectl
 toolchain. You will know if your underlying rules depend on the kubectl
 toolchain and the toolchain is not properly configured if you get one of the
 following errors

--- a/toolchains/kubectl/README.md
+++ b/toolchains/kubectl/README.md
@@ -4,37 +4,34 @@
 This section describes how the `kubectl` tool is configured using a toolchain
 rule. At the moment, the tool's configuration does one of the following:
 
-1. Build the `kubectl` tool from source (default).
-2. Detect the path to the `kubectl` tool.
+1. Detect the path to the `kubectl` tool (default).
+2. Build the `kubectl` tool from source.
 
 If you want to use the default (build the `kubectl` tool from source) you will
-need to add to your `WORKSPACE` file the following dependency:
+need to add to your `WORKSPACE` file the following lines (note the extra arg
+in the call to `k8s_repositories()`):
 
 ```python
- http_archive(
-    name = "io_bazel_rules_go",
-    urls = ["https://github.com/bazelbuild/rules_go/archive/0.16.1.tar.gz"],
-    sha256 = "ced2749527318abeddd9d91f5e1555ed86e2b6bfd08677b750396e0ec5462bec",
-    strip_prefix = "rules_go-0.16.1",
- )
+k8s_repositories(build_kubectl_srcs = True)
+
+load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
+
+go_rules_dependencies()
+
+go_register_toolchains()
 ```
 
-If you want the rules to detect the path to the `kubectl` tool you will
-need to add to your `WORKSPACE` file the `kubectl_configure` target before the
-`k8s_repositories` target:
+Note that by default the `k8s_repositories()` call configures a
+`kubectl_toolchain` that looks for the `kubectl` tool in the path.
+If no `kubectl` tool is found, trying to execute `bazel run` for any targets
+will not work.
 
-```python
-load("//toolchains/kubectl:kubectl_configure.bzl", "kubectl_configure")
+*NOTE: The lines above are required to create the dependencies and register
+the toolchain needed to build kubectl. If your project already imports*
+`io_bazel_rules_go` *make sure its at v0.16.1 or above.*
 
-kubectl_configure(name = "k8s_config")
-
-load("@io_bazel_rules_k8s//k8s:k8s.bzl", "k8s_repositories")
-
-k8s_repositories()
-```
-
-*NOTE: we are currently experimenting with toolchain features in these rules
-so there will be changes upcoming to how this configuration is performed*
+*NOTE: We are currently experimenting with toolchain features in these rules
+so there will be changes upcoming to how this configuration is performed.*
 
 ## Using the kubectl toolchain
 

--- a/toolchains/kubectl/kubectl_configure.bzl
+++ b/toolchains/kubectl/kubectl_configure.bzl
@@ -23,7 +23,7 @@ def _impl(repository_ctx):
         substitutions = {"%{KUBECTL_TARGET}": "%s" % kubectl_target}
         template = Label("@io_bazel_rules_k8s//toolchains/kubectl:BUILD.target.tpl")
     else:
-        kubectl_tool_path = repository_ctx.which("kubectl")
+        kubectl_tool_path = repository_ctx.which("kubectl") or ""
         substitutions = {"%{KUBECTL_TOOL}": "%s" % kubectl_tool_path}
         template = Label("@io_bazel_rules_k8s//toolchains/kubectl:BUILD.path.tpl")
 

--- a/toolchains/kubectl/kubectl_toolchain.bzl
+++ b/toolchains/kubectl/kubectl_toolchain.bzl
@@ -25,7 +25,7 @@ KubectlInfo = provider(
 
 def _kubectl_toolchain_impl(ctx):
     if not ctx.attr.tool_path and not ctx.attr.tool_target:
-        fail("Invalid kubectl_toolchain. kubectl_toolchain must have either tool_path or tool_target.")
+        print("No kubectl tool was found or built, executing run for rules_k8s targets might not work.")
     toolchain_info = platform_common.ToolchainInfo(
         kubectlinfo = KubectlInfo(
             tool_path = ctx.attr.tool_path,


### PR DESCRIPTION
* also make default (when importing these rules) to use kubectl from path (simpler atm, less error prone)
* provide instructions for how to use the new option to build kubectl from sources
* also show a nice error message if no kubectl tool is found when user attempts to do `bazel run` for a target that requires the toolchain is configured

https://github.com/bazelbuild/rules_k8s/issues/234 