### PR TITLE
update pin to rules_proto

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -3,36 +3,18 @@ platforms:
   ubuntu1404:
     build_targets:
     - "..."
-    # TODO(nlopezgi) remove once https://github.com/stackb/rules_proto/pull/2 is in.
-    build_flags:
-    - "--incompatible_remove_native_http_archive=false"
     test_targets:
     - "..."
-    # TODO(nlopezgi) remove once https://github.com/stackb/rules_proto/pull/2 is in.
-    test_flags:
-    - "--incompatible_remove_native_http_archive=false"
   ubuntu1604:
     build_targets:
     - "..."
-    # TODO(nlopezgi) remove once https://github.com/stackb/rules_proto/pull/2 is in.
-    build_flags:
-    - "--incompatible_remove_native_http_archive=false"
     test_targets:
     - "..."
-    # TODO(nlopezgi) remove once https://github.com/stackb/rules_proto/pull/2 is in.
-    test_flags:
-    - "--incompatible_remove_native_http_archive=false"
   macos:
     build_targets:
     - "--"
     - "..."
     - "-//images/gcloud-bazel:gcloud_install"
     - "-//images/gcloud-bazel:gcloud_push"
-    # TODO(nlopezgi) remove once https://github.com/stackb/rules_proto/pull/2 is in.
-    build_flags:
-    - "--incompatible_remove_native_http_archive=false"
     test_targets:
     - "..."
-    # TODO(nlopezgi) remove once https://github.com/stackb/rules_proto/pull/2 is in.
-    test_flags:
-    - "--incompatible_remove_native_http_archive=false"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -136,7 +136,7 @@ go_register_toolchains()
 
 http_archive(
     name = "build_stack_rules_proto",
-    #sha256 = "0be90d609fcefae9cc5e404540b9b23176fb609c9d62f4f9f68528f66a6839bf",
+    sha256 = "1d966be7d7dd2b22a3f684fafc6d138ad461edaa8a3133011e3a71dd1292a10d",
     strip_prefix = "rules_proto-8087f91f3d1080ce84c6d5a716ddc4993d325b69",
     urls = ["https://github.com/stackb/rules_proto/archive/8087f91f3d1080ce84c6d5a716ddc4993d325b69.tar.gz"],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -136,9 +136,9 @@ go_register_toolchains()
 
 http_archive(
     name = "build_stack_rules_proto",
-    sha256 = "0be90d609fcefae9cc5e404540b9b23176fb609c9d62f4f9f68528f66a6839bf",
-    strip_prefix = "rules_proto-4c2226458203a9653ae722245cc27e8b07c383f7",
-    urls = ["https://github.com/stackb/rules_proto/archive/4c2226458203a9653ae722245cc27e8b07c383f7.tar.gz"],
+    #sha256 = "0be90d609fcefae9cc5e404540b9b23176fb609c9d62f4f9f68528f66a6839bf",
+    strip_prefix = "rules_proto-8087f91f3d1080ce84c6d5a716ddc4993d325b69",
+    urls = ["https://github.com/stackb/rules_proto/archive/8087f91f3d1080ce84c6d5a716ddc4993d325b69.tar.gz"],
 )
 
 load("@build_stack_rules_proto//:deps.bzl", "io_grpc_grpc_java")


### PR DESCRIPTION
fixes https://github.com/bazelbuild/rules_k8s/issues/240

I found hard to fix issue since this repo depends on https://github.com/stackb/rules_proto which depends (https://github.com/stackb/rules_proto/blob/master/deps.bzl#L158) on https://github.com/grpc/grpc which depends (https://github.com/grpc/grpc/blob/d6c989936c0d6fdaf481e4ac460beaebc6c57f20/bazel/grpc_deps.bzl#L116) on https://github.com/protocolbuffers