### PR TITLE
Add a "substitutions" parameter to operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,40 @@ A rule for interacting with Kubernetes objects.
       </td>
     </tr>
     <tr>
+      <td><code>substitutions</code></td>
+      <td>
+        <p><code>string_dict, optional</code></p>
+        <p>Substitutions to make when expanding the template.</p>
+        <p>Follows the same rules as
+          <a href="https://docs.bazel.build/versions/master/skylark/lib/actions.html#expand_template">expand_template</a>
+          Values are <a href="https://docs.bazel.build/versions/master/be/make-variables.html">"make variable substituted."</a>
+          You can also use the Bazel command line option <code>--define</code>
+          to define your own custom variables.
+        </p>
+        <p><pre>
+  # Example
+  k8s_object(
+    name = "my_ingress",
+    kind = "ingress",
+
+    # A template of a Kubernetes ingress object yaml.
+    template = ":ingress.yaml",
+
+    # An optional collection of docker_build images to publish
+    # when this target is bazel run.  The digest of the published
+    # image is substituted as a part of the resolution process.
+    substitutions = {
+      "%{expand_template_variable}": "$(make_expanded_variable}",
+    })
+  </pre></p>
+        <p>Which is then invoked with <code>bazel run --define make_expanded_variable=value :target</code>
+        and will replace any occurrences of the literal token <code>%{expand_template_variable}</code> in your
+        template with the value "value" by way of first make variable
+        substitution and then expand_template replacement.
+        </p>
+      </td>
+    </tr>
+    <tr>
       <td><code>template</code></td>
       <td>
         <p><code>yaml or json file; required</code></p>

--- a/examples/hellogrpc/BUILD
+++ b/examples/hellogrpc/BUILD
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@bazel_tools//tools/build_rules:test_rules.bzl", "file_test")
 load("@io_bazel_rules_jsonnet//jsonnet:jsonnet.bzl", "jsonnet_to_json")
 load("@io_bazel_rules_k8s//k8s:objects.bzl", "k8s_objects")
 load("@k8s_deploy//:defaults.bzl", "k8s_deploy")
@@ -28,7 +29,32 @@ k8s_deploy(
 
 k8s_service(
     name = "staging-service",
+    substitutions = {
+        "%{SUBSTITUTED_ARGUMENT}": "substituted-value",
+    },
     template = "service.yaml",
+)
+
+file_test(
+    name = "staging-service-substitution-test",
+    content = """\
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: hello-grpc-staging
+    extratag: substituted-value
+  name: hello-grpc-staging
+spec:
+  ports:
+  - port: 50051
+    protocol: TCP
+    targetPort: 50051
+  selector:
+    app: hello-grpc-staging
+  type: LoadBalancer
+""",
+    file = ":staging-service.substituted.yaml",
 )
 
 k8s_objects(

--- a/examples/hellogrpc/service.yaml
+++ b/examples/hellogrpc/service.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   labels:
     app: hello-grpc-staging
+    extratag: %{SUBSTITUTED_ARGUMENT}
   name: hello-grpc-staging
 spec:
   ports:


### PR DESCRIPTION
The new "substitutions" parameter is passed to a call to
actions.expand_template on the template (json or yaml) that is passed
into k8s_object.

Fixes: #244