### PR TITLE
remove targets that cant run on Bazel CI

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -3,13 +3,19 @@ platforms:
   ubuntu1404:
     build_targets:
     - "..."
-    - "-//images/gcloud-bazel/..."
+    - "-//images//gcloud-bazel:gcloud_push"
+    - "-//images/gcloud-bazel:gcloud_installer"
+    - "-//images/gcloud-bazel:gcloud_install"
+    - "-//images/gcloud-bazel:gcloud-layer"
     test_targets:
     - "..."
   ubuntu1604:
     build_targets:
     - "..."
-    - "-//images/gcloud-bazel/..."
+    - "-//images//gcloud-bazel:gcloud_push"
+    - "-//images/gcloud-bazel:gcloud_installer"
+    - "-//images/gcloud-bazel:gcloud_install"
+    - "-//images/gcloud-bazel:gcloud-layer"
     test_targets:
     - "..."
   macos:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -2,6 +2,7 @@
 platforms:
   ubuntu1404:
     build_targets:
+    - "--"
     - "..."
     - "-//images//gcloud-bazel:gcloud_push"
     - "-//images/gcloud-bazel:gcloud_installer"
@@ -11,6 +12,7 @@ platforms:
     - "..."
   ubuntu1604:
     build_targets:
+    - "--"
     - "..."
     - "-//images//gcloud-bazel:gcloud_push"
     - "-//images/gcloud-bazel:gcloud_installer"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -3,11 +3,13 @@ platforms:
   ubuntu1404:
     build_targets:
     - "..."
+    - "-//images/gcloud-bazel/..."
     test_targets:
     - "..."
   ubuntu1604:
     build_targets:
     - "..."
+    - "-//images/gcloud-bazel/..."
     test_targets:
     - "..."
   macos:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -4,7 +4,7 @@ platforms:
     build_targets:
     - "--"
     - "..."
-    - "-//images//gcloud-bazel:gcloud_push"
+    - "-//images/gcloud-bazel:gcloud_push"
     - "-//images/gcloud-bazel:gcloud_installer"
     - "-//images/gcloud-bazel:gcloud_install"
     - "-//images/gcloud-bazel:gcloud-layer"
@@ -14,7 +14,7 @@ platforms:
     build_targets:
     - "--"
     - "..."
-    - "-//images//gcloud-bazel:gcloud_push"
+    - "-//images/gcloud-bazel:gcloud_push"
     - "-//images/gcloud-bazel:gcloud_installer"
     - "-//images/gcloud-bazel:gcloud_install"
     - "-//images/gcloud-bazel:gcloud-layer"


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/rules_k8s/issues/255

Bazel CI no longer has docker installed (it actually runs inside docker and they'd rather not have to setup sibling docker). Lets see if just removing some targets is enough to get this passing. We can probable get those targets running on BazelCi+RBE that does have docker