### PR TITLE
Fix buildifier 0.22.0 lint warnings

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,5 +1,4 @@
 ---
-buildifier: true
 platforms:
   ubuntu1404:
     build_targets:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,4 +1,6 @@
 ---
+# TODO (suvanjan): Re-enable once lint warnings have been fixed.
+# buildifier: true
 platforms:
   ubuntu1404:
     build_targets:

--- a/k8s/object.bzl
+++ b/k8s/object.bzl
@@ -31,15 +31,14 @@ def _runfiles(ctx, f):
     return "${RUNFILES}/%s" % _get_runfile_path(ctx, f)
 
 def _deduplicate(iterable):
-    """
-    Performs a deduplication (similar to `list(set(...))`,
-    but `set` is not available in Skylark).
+    """Performs a deduplication (similar to `list(set(...))`)
+
+    This is necessary because `set` is not available in Skylark.
     """
     return {k: None for k in iterable}.keys()
 
 def _add_dicts(*dicts):
-    """
-    Creates a new dict with a union of the elements of the arguments
+    """Creates a new dict with a union of the elements of the arguments
     """
     result = {}
     for d in dicts:
@@ -430,14 +429,16 @@ def _implicit_args_as_dict(**kwargs):
 
 def k8s_object(name, **kwargs):
     """Interact with a K8s object.
+
     Args:
       name: name of the rule.
-      cluster: the name of the cluster.
-      user: the user which has access to the cluster.
-      namespace: the namespace within the cluster.
-      kind: the object kind.
-      template: the yaml template to instantiate.
-      images: a dictionary from fully-qualified tag to label.
+      **kwargs: Other arguments accepted by k8s_object build rule.
+        cluster: the name of the cluster.
+        user: the user which has access to the cluster.
+        namespace: the namespace within the cluster.
+        kind: the object kind.
+        template: the yaml template to instantiate.
+        images: a dictionary from fully-qualified tag to label.
     """
     for reserved in ["image_targets", "image_target_strings", "resolved", "reversed"]:
         if reserved in kwargs:

--- a/k8s/objects.bzl
+++ b/k8s/objects.bzl
@@ -60,6 +60,7 @@ def k8s_objects(name, objects, **kwargs):
     Args:
       name: name of the rule.
       objects: list of k8s_object rules.
+      **kwargs: Pass through other arguments accepted by k8s_object.
     """
 
     # TODO(mattmoor): We may have to normalize the labels that come

--- a/test-e2e.sh
+++ b/test-e2e.sh
@@ -89,7 +89,7 @@ chmod +x ./buildifier
 # All warnings from https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md
 # are enabled except:
 # rule-impl-return, uninitialized, return-value
-# TODO (suvanjan): reenable once issues are fixed
+# TODO (suvanjan): reenable once issues are fixed and move to buildkite.
 ./buildifier --mode=check --warnings=attr-cfg,attr-license,attr-non-empty,attr-output-default,attr-single-file,confusing-name,constant-glob,ctx-actions,ctx-args,depset-iteration,depset-union,dict-concatenation,duplicated-name,filetype,function-docstring,git-repository,http-archive,integer-division,load,load-on-top,module-docstring,name-conventions,native-build,native-package,no-effect,out-of-order-load,output-group,package-name,package-on-top,positional-args,redefined-variable,repository-name,same-origin-load,string-iteration,unreachable,unsorted-dict-items,unused-variable $(find . -name BUILD -o -name WORKSPACE -o -name "*.bzl" -type f)
 ./buildifier --lint=warn --warnings=attr-cfg,attr-license,attr-non-empty,attr-output-default,attr-single-file,confusing-name,constant-glob,ctx-actions,ctx-args,depset-iteration,depset-union,dict-concatenation,duplicated-name,filetype,function-docstring,git-repository,http-archive,integer-division,load,load-on-top,module-docstring,name-conventions,native-build,native-package,no-effect,out-of-order-load,output-group,package-name,package-on-top,positional-args,redefined-variable,repository-name,same-origin-load,string-iteration,unreachable,unsorted-dict-items,unused-variable $(find . -name BUILD -o -name WORKSPACE -o -name "*.bzl" -type f)
 

--- a/test-e2e.sh
+++ b/test-e2e.sh
@@ -81,6 +81,18 @@ kubectl version
 # Don't build/test the prow image as it requires Docker
 EXCLUDED_TARGETS="-//images/gcloud-bazel:gcloud_install -//images/gcloud-bazel:gcloud_push"
 
+# Install buildifier 0.22.0 and run lint checks
+wget -q https://github.com/bazelbuild/buildtools/releases/download/0.22.0/buildifier
+chmod +x ./buildifier
+
+# Check for issues with the format of our bazel config files.
+# All warnings from https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md
+# are enabled except:
+# rule-impl-return, uninitialized, return-value
+# TODO (suvanjan): reenable once issues are fixed
+./buildifier --mode=check --warnings=attr-cfg,attr-license,attr-non-empty,attr-output-default,attr-single-file,confusing-name,constant-glob,ctx-actions,ctx-args,depset-iteration,depset-union,dict-concatenation,duplicated-name,filetype,function-docstring,git-repository,http-archive,integer-division,load,load-on-top,module-docstring,name-conventions,native-build,native-package,no-effect,out-of-order-load,output-group,package-name,package-on-top,positional-args,redefined-variable,repository-name,same-origin-load,string-iteration,unreachable,unsorted-dict-items,unused-variable $(find . -name BUILD -o -name WORKSPACE -o -name "*.bzl" -type f)
+./buildifier --lint=warn --warnings=attr-cfg,attr-license,attr-non-empty,attr-output-default,attr-single-file,confusing-name,constant-glob,ctx-actions,ctx-args,depset-iteration,depset-union,dict-concatenation,duplicated-name,filetype,function-docstring,git-repository,http-archive,integer-division,load,load-on-top,module-docstring,name-conventions,native-build,native-package,no-effect,out-of-order-load,output-group,package-name,package-on-top,positional-args,redefined-variable,repository-name,same-origin-load,string-iteration,unreachable,unsorted-dict-items,unused-variable $(find . -name BUILD -o -name WORKSPACE -o -name "*.bzl" -type f)
+
 # Check that all of our tools and samples build
 bazel build -- //... $EXCLUDED_TARGETS
 bazel test  -- //... $EXCLUDED_TARGETS

--- a/toolchains/kubectl/kubectl_configure.bzl
+++ b/toolchains/kubectl/kubectl_configure.bzl
@@ -68,7 +68,8 @@ _kubectl_configure = repository_rule(
 )
 
 def _ensure_all_provided(func_name, attrs, kwargs):
-    """
+    """Ensures all the required arguments in the given function were specified.
+
     For function func_name, ensure either all attributes in 'attrs' were
     specified in kwargs or none were specified.
     """
@@ -94,28 +95,30 @@ def _ensure_all_provided(func_name, attrs, kwargs):
         ))
 
 def kubectl_configure(name, **kwargs):
-    """
-    Creates an external repository with a kubectl_toolchain target
-    properly configured.
+    """Creates an external repository with a configured kubectl_toolchain target.
+
+    Note: Not all versions/commits of kubernetes project can be used to compile
+    kubectl from an external repo. Notably, we have only tested with v1.13.0-beta.1
+    or above. Note this rule has a hardcoded pointer to io_kubernetes_build repo
+    if your commit (above v1.13.0-beta.1) does not work due to problems,
+    related to @io_kubernetes_build repo, please send a PR to update these values.
 
     Args:
+        name: Name of the build target.
         **kwargs:
-      Required Args
-        name: A unique name for this rule.
-      Default Args:
-        build_srcs: Optional. Set to true to build kubectl from sources. Default: False.
-                    Can't be specified if kubectl_path is specified.
-        k8s_commit: Optional. Commit / release tag at which to build kubectl
-          from. Default is defined as k8s_tag in :defaults.bzl.
-        k8s_sha256: Optional. sha256 of commit at which to build kubectl from.
-          Default is defined as k8s_sha256 in :defaults.bzl.
-        kubectl_path: Optional. Use the kubectl binary at the given path or label.
-        This can't be used with 'build_srcs'.
-      Note: Not all versions/commits of kubernetes project can be used to compile
-      kubectl from an external repo. Notably, we have only tested with v1.13.0-beta.1
-      or above. Note this rule has a hardcoded pointer to io_kubernetes_build repo
-      if your commit (above v1.13.0-beta.1) does not work due to problems,
-      related to @io_kubernetes_build repo, please send a PR to update these values.
+            Required Args
+                name: A unique name for this rule.
+            Default Args:
+                build_srcs: Optional. Set to true to build kubectl from sources.
+                            Default: False. Can't be specified if kubectl_path
+                            is specified.
+                k8s_commit: Optional. Commit / release tag at which to build
+                            kubectl from. Default is defined as k8s_tag in
+                            :defaults.bzl.
+                k8s_sha256: Optional. sha256 of commit at which to build kubectl
+                from. Default is defined as k8s_sha256 in :defaults.bzl.
+                kubectl_path: Optional. Use the kubectl binary at the given path
+                or label. This can't be used with 'build_srcs'.
     """
     build_srcs = False
     if "build_srcs" in kwargs and "kubectl_path" in kwargs:


### PR DESCRIPTION
Disabled buildifier in buildkite and enabled it in e2e tests with
specific warnings disabled.