### PR TITLE
rules_k8s: Support passing in a kubeconfig file

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,15 @@ A rule for interacting with Kubernetes objects.
       </td>
     </tr>
     <tr>
+      <td><code>kubeconfig</code></td>
+      <td>
+        <p><code>kubeconfig file, optional</code></p>
+        <p>The kubeconfig file to pass to the `kubectl` tool via the
+          `--kubeconfig` option. Can be useful if the `kubeconfig` is generated
+          by another target.</p>
+      </td>
+    </tr>
+    <tr>
       <td><code>substitutions</code></td>
       <td>
         <p><code>string_dict, optional</code></p>

--- a/examples/hellogrpc/BUILD
+++ b/examples/hellogrpc/BUILD
@@ -27,6 +27,12 @@ k8s_deploy(
     template = "deployment.yaml",
 )
 
+k8s_deploy(
+    name = "staging-deployment-with-kubeconfig",
+    kubeconfig = ":kubeconfig",
+    template = "deployment.yaml",
+)
+
 k8s_service(
     name = "staging-service",
     substitutions = {
@@ -76,6 +82,14 @@ jsonnet_to_json(
         "//examples:container_lib",
         "//examples:deploy_lib",
     ],
+)
+
+# Generate an empty kubeconfig for testing
+genrule(
+    name = "kubeconfig",
+    srcs = [],
+    outs = ["kubeconfig.out"],
+    cmd = "touch $@",
 )
 
 # Verify that deployment.json == deployment.yaml

--- a/k8s/apply.sh.tpl
+++ b/k8s/apply.sh.tpl
@@ -26,4 +26,5 @@ function exe() { echo "\$ ${@/eval/}" ; "$@" ; }
 RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
 
 PYTHON_RUNFILES=${RUNFILES} %{resolve_script} | \
-  exe  %{kubectl_tool} --cluster="%{cluster}" --context="%{context}" --user="%{user}" %{namespace_arg} apply $@ -f -
+  exe  %{kubectl_tool} --kubeconfig="%{kubeconfig}" --cluster="%{cluster}" \
+  --context="%{context}" --user="%{user}" %{namespace_arg} apply $@ -f -

--- a/k8s/create.sh.tpl
+++ b/k8s/create.sh.tpl
@@ -28,4 +28,5 @@ RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
 # TODO(mattmoor): Should we create namespaces that do not exist?
 
 PYTHON_RUNFILES=${RUNFILES} %{resolve_script} | \
-  exe %{kubectl_tool} --cluster="%{cluster}" --context="%{context}" --user="%{user}" %{namespace_arg} create $@ -f -
+  exe %{kubectl_tool} --kubeconfig="%{kubeconfig}" --cluster="%{cluster}" \
+  --context="%{context}" --user="%{user}" %{namespace_arg} create $@ -f -

--- a/k8s/object.bzl
+++ b/k8s/object.bzl
@@ -181,6 +181,12 @@ def _common_impl(ctx):
     if namespace_arg:
         namespace_arg = "--namespace=\"" + namespace_arg + "\""
 
+    if ctx.file.kubeconfig:
+        kubeconfig_arg = _runfiles(ctx, ctx.file.kubeconfig)
+        files += [ctx.file.kubeconfig]
+    else:
+        kubeconfig_arg = ""
+
     kubectl_tool_info = ctx.toolchains["@io_bazel_rules_k8s//toolchains/kubectl:toolchain_type"].kubectlinfo
     if kubectl_tool_info.tool_path == "" and not kubectl_tool_info.tool_target:
         # If tool_path is empty and tool_target is None then there is no local
@@ -200,6 +206,7 @@ def _common_impl(ctx):
             "%{cluster}": cluster_arg,
             "%{context}": context_arg,
             "%{kind}": ctx.attr.kind,
+            "%{kubeconfig}": kubeconfig_arg,
             "%{kubectl_tool}": kubectl_tool,
             "%{namespace_arg}": namespace_arg,
             "%{user}": user_arg,
@@ -235,6 +242,9 @@ _common_attrs = {
     "image_chroot": attr.string(),
     # This is only needed for describe.
     "kind": attr.string(),
+    "kubeconfig": attr.label(
+        allow_single_file = True,
+    ),
     "namespace": attr.string(),
     "resolver": attr.label(
         default = Label("//k8s:resolver"),
@@ -455,6 +465,7 @@ def k8s_object(name, **kwargs):
         cluster: the name of the cluster.
         user: the user which has access to the cluster.
         namespace: the namespace within the cluster.
+        kubeconfig: the kubeconfig file to use with kubectl.
         kind: the object kind.
         template: the yaml template to instantiate.
         images: a dictionary from fully-qualified tag to label.
@@ -482,6 +493,7 @@ def k8s_object(name, **kwargs):
             kind = kwargs.get("kind"),
             cluster = kwargs.get("cluster"),
             context = kwargs.get("context"),
+            kubeconfig = kwargs.get("kubeconfig"),
             user = kwargs.get("user"),
             namespace = kwargs.get("namespace"),
             args = kwargs.get("args"),
@@ -493,6 +505,7 @@ def k8s_object(name, **kwargs):
             kind = kwargs.get("kind"),
             cluster = kwargs.get("cluster"),
             context = kwargs.get("context"),
+            kubeconfig = kwargs.get("kubeconfig"),
             user = kwargs.get("user"),
             namespace = kwargs.get("namespace"),
             args = kwargs.get("args"),
@@ -504,6 +517,7 @@ def k8s_object(name, **kwargs):
             kind = kwargs.get("kind"),
             cluster = kwargs.get("cluster"),
             context = kwargs.get("context"),
+            kubeconfig = kwargs.get("kubeconfig"),
             user = kwargs.get("user"),
             namespace = kwargs.get("namespace"),
             args = kwargs.get("args"),
@@ -515,6 +529,7 @@ def k8s_object(name, **kwargs):
             kind = kwargs.get("kind"),
             cluster = kwargs.get("cluster"),
             context = kwargs.get("context"),
+            kubeconfig = kwargs.get("kubeconfig"),
             user = kwargs.get("user"),
             namespace = kwargs.get("namespace"),
             args = kwargs.get("args"),
@@ -527,6 +542,7 @@ def k8s_object(name, **kwargs):
                 kind = kwargs.get("kind"),
                 cluster = kwargs.get("cluster"),
                 context = kwargs.get("context"),
+                kubeconfig = kwargs.get("kubeconfig"),
                 user = kwargs.get("user"),
                 namespace = kwargs.get("namespace"),
                 args = kwargs.get("args"),


### PR DESCRIPTION
Add support for passing in a generated kubeconfig file to `rules_k8s`
objects. This can be used to pass in a configuration that's generated by
Bazel.