### PR TITLE
Return providers instead of struct from rule impl functions

### DIFF
--- a/k8s/object.bzl
+++ b/k8s/object.bzl
@@ -122,10 +122,13 @@ def _impl(ctx):
 
     return [
         DefaultInfo(
-            runfiles = ctx.runfiles(files = [
-                ctx.executable.resolver,
-                ctx.outputs.substituted,
-            ] + list(ctx.attr.resolver[DefaultInfo].default_runfiles.files) + all_inputs),
+            runfiles = ctx.runfiles(
+                files = [
+                    ctx.executable.resolver,
+                    ctx.outputs.substituted,
+                ],
+                transitive_files = list(ctx.attr.resolver[DefaultInfo].default_runfiles.files) + all_inputs,
+            ),
         ),
     ]
 
@@ -284,10 +287,13 @@ def _reverse(ctx):
 
     return [
         DefaultInfo(
-            runfiles = ctx.runfiles(files = [
-                ctx.executable.reverser,
-                ctx.file.template,
-            ] + list(ctx.attr.reverser[DefaultInfo].default_runfiles.files)),
+            runfiles = ctx.runfiles(
+                files = [
+                    ctx.executable.reverser,
+                    ctx.file.template,
+                ],
+                transitive_files = list(ctx.attr.reverser[DefaultInfo].default_runfiles.files),
+            ),
         ),
     ]
 

--- a/k8s/object.bzl
+++ b/k8s/object.bzl
@@ -125,7 +125,7 @@ def _impl(ctx):
             runfiles = ctx.runfiles(files = [
                 ctx.executable.resolver,
                 ctx.outputs.substituted,
-            ] + list(ctx.attr.resolver.default_runfiles.files) + all_inputs),
+            ] + list(ctx.attr.resolver[DefaultInfo].default_runfiles.files) + all_inputs),
         ),
     ]
 
@@ -219,12 +219,12 @@ def _common_impl(ctx):
         if hasattr(ctx.executable, "resolved"):
             substitutions["%{resolve_script}"] = _runfiles(ctx, ctx.executable.resolved)
             files += [ctx.executable.resolved]
-            files += list(ctx.attr.resolved.default_runfiles.files)
+            files += list(ctx.attr.resolved[DefaultInfo].default_runfiles.files)
 
         if hasattr(ctx.executable, "reversed"):
             substitutions["%{reverse_script}"] = _runfiles(ctx, ctx.executable.reversed)
             files += [ctx.executable.reversed]
-            files += list(ctx.attr.reversed.default_runfiles.files)
+            files += list(ctx.attr.reversed[DefaultInfo].default_runfiles.files)
 
         if hasattr(ctx.files, "unresolved"):
             substitutions["%{unresolved}"] = _runfiles(ctx, ctx.file.unresolved)
@@ -287,7 +287,7 @@ def _reverse(ctx):
             runfiles = ctx.runfiles(files = [
                 ctx.executable.reverser,
                 ctx.file.template,
-            ] + list(ctx.attr.reverser.default_runfiles.files)),
+            ] + list(ctx.attr.reverser[DefaultInfo].default_runfiles.files)),
         ),
     ]
 

--- a/k8s/object.bzl
+++ b/k8s/object.bzl
@@ -125,7 +125,7 @@ def _impl(ctx):
             runfiles = ctx.runfiles(files = [
                 ctx.executable.resolver,
                 ctx.outputs.substituted,
-            ] + list(ctx.attr.resolver.default_runfiles.files) + all_inputs)
+            ] + list(ctx.attr.resolver.default_runfiles.files) + all_inputs),
         ),
     ]
 
@@ -287,7 +287,7 @@ def _reverse(ctx):
             runfiles = ctx.runfiles(files = [
                 ctx.executable.reverser,
                 ctx.file.template,
-            ] + list(ctx.attr.reverser.default_runfiles.files))
+            ] + list(ctx.attr.reverser.default_runfiles.files)),
         ),
     ]
 

--- a/k8s/object.bzl
+++ b/k8s/object.bzl
@@ -120,10 +120,14 @@ def _impl(ctx):
         output = ctx.outputs.executable,
     )
 
-    return struct(runfiles = ctx.runfiles(files = [
-        ctx.executable.resolver,
-        ctx.outputs.substituted,
-    ] + list(ctx.attr.resolver.default_runfiles.files) + all_inputs))
+    return [
+        DefaultInfo(
+            runfiles = ctx.runfiles(files = [
+                ctx.executable.resolver,
+                ctx.outputs.substituted,
+            ] + list(ctx.attr.resolver.default_runfiles.files) + all_inputs)
+        ),
+    ]
 
 def _resolve(ctx, string, output):
     stamps = [ctx.info_file, ctx.version_file]
@@ -232,7 +236,11 @@ def _common_impl(ctx):
             output = ctx.outputs.executable,
         )
 
-    return struct(runfiles = ctx.runfiles(files = files))
+    return [
+        DefaultInfo(
+            runfiles = ctx.runfiles(files = files),
+        ),
+    ]
 
 _common_attrs = {
     # We allow cluster to be omitted, and we just
@@ -274,10 +282,14 @@ def _reverse(ctx):
         output = ctx.outputs.executable,
     )
 
-    return struct(runfiles = ctx.runfiles(files = [
-        ctx.executable.reverser,
-        ctx.file.template,
-    ] + list(ctx.attr.reverser.default_runfiles.files)))
+    return [
+        DefaultInfo(
+            runfiles = ctx.runfiles(files = [
+                ctx.executable.reverser,
+                ctx.file.template,
+            ] + list(ctx.attr.reverser.default_runfiles.files))
+        ),
+    ]
 
 _reversed = rule(
     attrs = _add_dicts(

--- a/k8s/object.bzl
+++ b/k8s/object.bzl
@@ -126,8 +126,8 @@ def _impl(ctx):
                 files = [
                     ctx.executable.resolver,
                     ctx.outputs.substituted,
-                ],
-                transitive_files = list(ctx.attr.resolver[DefaultInfo].default_runfiles.files) + all_inputs,
+                ] + all_inputs,
+                transitive_files = ctx.attr.resolver[DefaultInfo].default_runfiles.files,
             ),
         ),
     ]
@@ -292,7 +292,7 @@ def _reverse(ctx):
                     ctx.executable.reverser,
                     ctx.file.template,
                 ],
-                transitive_files = list(ctx.attr.reverser[DefaultInfo].default_runfiles.files),
+                transitive_files = ctx.attr.reverser[DefaultInfo].default_runfiles.files,
             ),
         ),
     ]

--- a/k8s/objects.bzl
+++ b/k8s/objects.bzl
@@ -37,7 +37,11 @@ def _run_all_impl(ctx):
     for obj in ctx.attr.objects:
         runfiles += list(obj.default_runfiles.files)
 
-    return struct(runfiles = ctx.runfiles(files = runfiles))
+    return [
+        DefaultInfo(
+            runfiles = ctx.runfiles(files = runfiles),
+        ),
+    ]
 
 _run_all = rule(
     attrs = {


### PR DESCRIPTION
This addresses the incompatible change via the `--incompatible_disallow_struct_provider_syntax` flag described [here](https://github.com/bazelbuild/bazel/issues/7347).