### PR TITLE
Allow kubeconfig in k8s_defaults and .delete rules

### DIFF
--- a/examples/hellogrpc/e2e-test.sh
+++ b/examples/hellogrpc/e2e-test.sh
@@ -114,9 +114,11 @@ delete() {
 }
 
 check_kubeconfig_args() {
-  bazel build examples/hellogrpc:staging-deployment-with-kubeconfig.apply
-  OUTPUT="$(cat ./bazel-bin/examples/hellogrpc/staging-deployment-with-kubeconfig.apply)"
-  EXPECT_CONTAINS_PATTERN "${OUTPUT}" "--kubeconfig=\S*/examples/hellogrpc/kubeconfig.out"
+  for cmd in apply delete; do
+    bazel build examples/hellogrpc:staging-deployment-with-kubeconfig.${cmd}
+    OUTPUT="$(cat ./bazel-bin/examples/hellogrpc/staging-deployment-with-kubeconfig.${cmd})"
+    EXPECT_CONTAINS_PATTERN "${OUTPUT}" "--kubeconfig=\S*/examples/hellogrpc/kubeconfig.out"
+  done
 }
 
 # e2e test that checks that args are added to the kubectl apply command

--- a/k8s/delete.sh.tpl
+++ b/k8s/delete.sh.tpl
@@ -26,4 +26,5 @@ function exe() { echo "\$ ${@/eval/}" ; "$@" ; }
 RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
 
 PYTHON_RUNFILES=${RUNFILES} %{reverse_script} | \
-  exe %{kubectl_tool} --cluster="%{cluster}" --context="%{context}" --user="%{user}" %{namespace_arg} delete $@ --ignore-not-found=true -f -
+  exe %{kubectl_tool} --kubeconfig="%{kubeconfig}" --cluster="%{cluster}" \
+  --context="%{context}" --user="%{user}" %{namespace_arg} delete $@ --ignore-not-found=true -f -

--- a/k8s/with-defaults.bzl
+++ b/k8s/with-defaults.bzl
@@ -87,6 +87,13 @@ def _impl(repository_ctx):
             repository_ctx.attr.kind,
         )]
 
+    if repository_ctx.attr.kubeconfig:
+        overrides += [_override(
+            repository_ctx.attr.name,
+            "kubeconfig",
+            repository_ctx.attr.kubeconfig,
+        )]
+
     if repository_ctx.attr.image_chroot:
         overrides += [_override(
             repository_ctx.attr.name,
@@ -120,6 +127,7 @@ k8s_defaults = repository_rule(
         "context": attr.string(mandatory = False),
         "image_chroot": attr.string(mandatory = False),
         "kind": attr.string(mandatory = False),
+        "kubeconfig": attr.string(mandatory = False),
         "namespace": attr.string(mandatory = False),
         "resolver": attr.string(mandatory = False),
         "user": attr.string(mandatory = False),


### PR DESCRIPTION
It is now possible to use `kubeconfig` in `k8s_defaults`, which we use with k3s internally.
In `.delete` rules, `kubeconfig` was ignored, so fix that.