### PR TITLE
Add support for select statement for k8s_objects.

### DIFF
--- a/README.md
+++ b/README.md
@@ -611,7 +611,7 @@ A rule for interacting with multiple Kubernetes objects.
 	<p>When <code>bazel run</code> this target resolves each of the object
 	   targets which includes publishing their associated images, and will
 	   print a <code>---</code> delimited yaml.</p>
-        <p> If a dict is provided it will be converted to a [select](https://docs.bazel.build/versions/master/be/functions.html) statement.</p>
+        <p> If a dict is provided it will be converted to a <a href="https://docs.bazel.build/versions/master/be/functions.html">select</a> statement.</p>
       </td>
     </tr>
   </tbody>

--- a/README.md
+++ b/README.md
@@ -606,11 +606,12 @@ A rule for interacting with multiple Kubernetes objects.
     <tr>
       <td><code>objects</code></td>
       <td>
-        <p><code>Label list; required</code></p>
+        <p><code>Label list or dict; required</code></p>
         <p>The list of objects on which actions are taken.</p>
 	<p>When <code>bazel run</code> this target resolves each of the object
 	   targets which includes publishing their associated images, and will
 	   print a <code>---</code> delimited yaml.</p>
+        <p> If a dict is provided it will be converted to a [select](https://docs.bazel.build/versions/master/be/functions.html) statement.</p>
       </td>
     </tr>
   </tbody>

--- a/examples/hellogrpc/BUILD
+++ b/examples/hellogrpc/BUILD
@@ -63,15 +63,24 @@ spec:
     file = ":staging-service.substituted.yaml",
 )
 
+config_setting(
+    name = "is_prod",
+    define_values = {"environment": "staging"},
+    visibility = ["//visibility:public"],
+)
+
 k8s_objects(
     name = "staging",
     args = [
         "--v=2",
     ],
-    objects = [
-        ":staging-deployment",
-        ":staging-service",
-    ],
+    objects = {
+        ":is_prod": [],
+        "//conditions:default": [
+            ":staging-deployment",
+            ":staging-service",
+        ],
+    },
 )
 
 jsonnet_to_json(

--- a/k8s/objects.bzl
+++ b/k8s/objects.bzl
@@ -58,13 +58,13 @@ _run_all = rule(
     implementation = _run_all_impl,
 )
 
-def _reverse(lis, reverse=False):
+def _reverse(lis, reverse = False):
     if reverse:
         return reversed(lis)
     else:
         return lis
 
-def _cmd_objects(cmd, objects, reverse=False):
+def _cmd_objects(cmd, objects, reverse = False):
     if type(objects) == "dict":
         return select({k: [x + cmd for x in _reverse(v, reverse)] for k, v in objects.items()})
     else:

--- a/k8s/objects.bzl
+++ b/k8s/objects.bzl
@@ -58,13 +58,13 @@ _run_all = rule(
     implementation = _run_all_impl,
 )
 
-def _reverse(l, reverse=False):
+def _reverse(lis, reverse=False):
     if reverse:
-        return reversed(l)
+        return reversed(lis)
     else:
-        return l
+        return lis
 
-def _cmd_select(cmd, objects, reverse=False):
+def _cmd_objects(cmd, objects, reverse=False):
     if type(objects) == "dict":
         return select({k: [x + cmd for x in _reverse(v, reverse)] for k, v in objects.items()})
     else:
@@ -81,8 +81,8 @@ def k8s_objects(name, objects, **kwargs):
 
     # TODO(mattmoor): We may have to normalize the labels that come
     # in through objects.
-    _run_all(name = name, objects = _cmd_select("", objects), delimiter = "echo ---\n", **kwargs)
-    _run_all(name = name + ".create", objects = _cmd_select(".create", objects), **kwargs)
-    _run_all(name = name + ".delete", objects = _cmd_select(".delete", objects, True), **kwargs)
-    _run_all(name = name + ".replace", objects = _cmd_select(".replace", objects), **kwargs)
-    _run_all(name = name + ".apply", objects = _cmd_select(".apply", objects), **kwargs)
+    _run_all(name = name, objects = _cmd_objects("", objects), delimiter = "echo ---\n", **kwargs)
+    _run_all(name = name + ".create", objects = _cmd_objects(".create", objects), **kwargs)
+    _run_all(name = name + ".delete", objects = _cmd_objects(".delete", objects, True), **kwargs)
+    _run_all(name = name + ".replace", objects = _cmd_objects(".replace", objects), **kwargs)
+    _run_all(name = name + ".apply", objects = _cmd_objects(".apply", objects), **kwargs)

--- a/k8s/objects.bzl
+++ b/k8s/objects.bzl
@@ -59,12 +59,25 @@ _run_all = rule(
 )
 
 def _reverse(lis, reverse = False):
+    """Returns a reversed list if if reverse is true
+
+    Args:
+      lis: The list to be potentially reversed
+      reverse: If True the provided list will be reversed
+    """
     if reverse:
         return reversed(lis)
     else:
         return lis
 
 def _cmd_objects(cmd, objects, reverse = False):
+    """Returns either a list or a select statement of objects for the provided cmd
+
+    Args:
+      cmd: name of the command that will be appended to each object
+      objects: The objects that will get the cmd appended
+      reverse: If the order of the objects should be reversed or not
+    """
     if type(objects) == "dict":
         return select({k: [x + cmd for x in _reverse(v, reverse)] for k, v in objects.items()})
     else:


### PR DESCRIPTION
We are making use of `--define` flags to deploy targets into different environments. Right now we are making use of an `alias` to achieve this but it has limitations and adds code complexity that we would like to remove. Unfortunately macros can not manipulate `select` statements directly so I have to treat a `dict` as a special case. See https://github.com/bazelbuild/bazel/issues/8419