### PR TITLE
fix: building kubectl v1.14.3 fails with missing dependency

### DIFF
--- a/toolchains/kubectl/kubectl_configure.bzl
+++ b/toolchains/kubectl/kubectl_configure.bzl
@@ -155,7 +155,7 @@ def kubectl_configure(name, **kwargs):
             ))],
         )
         http_archive(
-            name = "io_kubernetes_build",
+            name = "io_k8s_repo_infra",
             sha256 = k8s_repo_tools_sha,
             strip_prefix = k8s_repo_tools_prefix,
             urls = ["https://github.com/{}/{}/archive/{}.tar.gz".format(
@@ -164,6 +164,7 @@ def kubectl_configure(name, **kwargs):
                 k8s_repo_tools_commit,
             )],
         )
+
     if "kubectl_path" in kwargs:
         _kubectl_configure(name = name, kubectl_path = kwargs["kubectl_path"])
     else:


### PR DESCRIPTION
The kubernetes repo expects io_kubernetes_build to be called io_k8s_repo_infra.
If that repository is not available the build will fail with the following error message.
"error loading package '@io_kubernetes//staging/src/k8s.io/apimachinery/pkg/util/sets': Unable to find package for @io_k8s_repo_infra//defs:go.bzl: The repository '@io_k8s_repo_infra' could not be resolved."

Related change:
https://github.com/kubernetes/kubernetes/commit/e216995ef15a0e2a64f7742e5d5b7965170e4dcf

Fixes #358 

This likely breaks backward compatibility with kubernetes < 1.14
Is there any good way to parse versions in skylark?