### PR TITLE
Add .diff command

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ bazel run :dev.diff
 `:dev.diff` maps to `kubectl diff`, which will diff the live against the would-be applied version.
 For more information see the `kubectl` documentation.
 
-This applies the **resolved** template, which includes republishing images.
+This diffs the **resolved** template, but does not include republishing images.
 
 <a name="k8s_object"></a>
 ## k8s_object

--- a/README.md
+++ b/README.md
@@ -422,6 +422,18 @@ Users can "describe" their environment by running:
 bazel run :dev.describe
 ```
 
+### Diff
+
+Users can "diff" a configuration by running:
+```shell
+bazel run :dev.diff
+```
+
+`:dev.diff` maps to `kubectl diff`, which will diff the live against the would-be applied version.
+For more information see the `kubectl` documentation.
+
+This applies the **resolved** template, which includes republishing images.
+
 <a name="k8s_object"></a>
 ## k8s_object
 

--- a/k8s/BUILD
+++ b/k8s/BUILD
@@ -27,6 +27,7 @@ exports_files([
     "reverse.sh.tpl",
     "delete.sh.tpl",
     "describe.sh.tpl",
+    "diff.sh.tpl",
 ])
 
 py_library(

--- a/k8s/diff.sh.tpl
+++ b/k8s/diff.sh.tpl
@@ -25,6 +25,6 @@ function exe() { echo "\$ ${@/eval/}" ; "$@" ; }
 
 RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
 
-PYTHON_RUNFILES=${RUNFILES} %{resolve_script} | \
+PYTHON_RUNFILES=${RUNFILES} %{resolve_script} --no_push | \
   exe  %{kubectl_tool} --kubeconfig="%{kubeconfig}" --cluster="%{cluster}" \
   --context="%{context}" --user="%{user}" %{namespace_arg} diff $@ -f -

--- a/k8s/diff.sh.tpl
+++ b/k8s/diff.sh.tpl
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -euo pipefail
+
+function guess_runfiles() {
+    pushd ${BASH_SOURCE[0]}.runfiles > /dev/null 2>&1
+    pwd
+    popd > /dev/null 2>&1
+}
+
+function exe() { echo "\$ ${@/eval/}" ; "$@" ; }
+
+RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
+
+PYTHON_RUNFILES=${RUNFILES} %{resolve_script} | \
+  exe  %{kubectl_tool} --kubeconfig="%{kubeconfig}" --cluster="%{cluster}" \
+  --context="%{context}" --user="%{user}" %{namespace_arg} diff $@ -f -

--- a/k8s/object.bzl
+++ b/k8s/object.bzl
@@ -458,6 +458,26 @@ _k8s_object_delete = rule(
     implementation = _common_impl,
 )
 
+_k8s_object_diff = rule(
+    attrs = _add_dicts(
+        {
+            "resolved": attr.label(
+                cfg = "target",
+                executable = True,
+                allow_files = True,
+            ),
+            "_template": attr.label(
+                default = Label("//k8s:diff.sh.tpl"),
+                allow_single_file = True,
+            ),
+        },
+        _common_attrs,
+    ),
+    executable = True,
+    toolchains = ["@io_bazel_rules_k8s//toolchains/kubectl:toolchain_type"],
+    implementation = _common_impl,
+)
+
 # See "attrs" parameter at https://docs.bazel.build/versions/master/skylark/lib/globals.html#parameters-26
 _implicit_attrs = [
     "visibility",
@@ -546,6 +566,18 @@ def k8s_object(name, **kwargs):
         )
         _k8s_object_apply(
             name = name + ".apply",
+            resolved = name,
+            kind = kwargs.get("kind"),
+            cluster = kwargs.get("cluster"),
+            context = kwargs.get("context"),
+            kubeconfig = kwargs.get("kubeconfig"),
+            user = kwargs.get("user"),
+            namespace = kwargs.get("namespace"),
+            args = kwargs.get("args"),
+            **implicit_args
+        )
+        _k8s_object_diff(
+            name = name + ".diff",
             resolved = name,
             kind = kwargs.get("kind"),
             cluster = kwargs.get("cluster"),

--- a/k8s/objects.bzl
+++ b/k8s/objects.bzl
@@ -99,3 +99,4 @@ def k8s_objects(name, objects, **kwargs):
     _run_all(name = name + ".delete", objects = _cmd_objects(".delete", objects, True), **kwargs)
     _run_all(name = name + ".replace", objects = _cmd_objects(".replace", objects), **kwargs)
     _run_all(name = name + ".apply", objects = _cmd_objects(".apply", objects), **kwargs)
+    _run_all(name = name + ".diff", objects = _cmd_objects(".diff", objects), **kwargs)

--- a/k8s/resolver.py
+++ b/k8s/resolver.py
@@ -119,7 +119,7 @@ def StringToDigest(string, overrides, transport):
     return str(digest)
 
 
-def Publish(transport, image_chroot, no_push,
+def Publish(transport, image_chroot, no_push=False,
             name=None, tarball=None, config=None, digest=None, layer=None):
   if not name:
     raise Exception('Expected "name" kwarg')
@@ -182,7 +182,7 @@ def main():
     parts = spec.split(';')
     kwargs = dict([x.split('=', 2) for x in parts])
     try:
-      (tag, digest) = Publish(transport, args.image_chroot, args.no_push, **kwargs)
+      (tag, digest) = Publish(transport, args.image_chroot, no_push=args.no_push, **kwargs)
       overrides[tag] = digest
       unseen_strings.add(tag)
     except Exception as e:


### PR DESCRIPTION
Now that `diff` is released, this adds a `.diff` command. In order to avoid pushing when resolving for the purposes of the diff, this also adds a `no_push` flag to `resolver.py`

Fixes #242 