### PR TITLE
feat: support stamping repository tags for images

### DIFF
--- a/examples/imagestamping/BUILD
+++ b/examples/imagestamping/BUILD
@@ -19,11 +19,11 @@ package(default_visibility = ["//visibility:public"])
 licenses(["notice"])  # Apache 2.0
 
 k8s_object(
-    name = "image-stamping",
+    name = "imagestamping-image",
     # Build images with the same container
     images = {
         "index.docker.io/parsec86/{REPOSITORY}:{STABLE_GIT_COMMIT}": "//examples/imagestamping/go:go-container",
     },
-    # K8s deployment template wtih a stamping variable to replace
+    # K8s deployment template with a stamping variable to replace
     template = ":deployment.yaml",
 )

--- a/examples/imagestamping/BUILD
+++ b/examples/imagestamping/BUILD
@@ -18,13 +18,12 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
-
 k8s_object(
     name = "image-stamping",
-    # K8s deployment template wtih a stamping variable to replace
-    template = ":deployment.yaml",
     # Build images with the same container
     images = {
         "index.docker.io/parsec86/{REPOSITORY}:{STABLE_GIT_COMMIT}": "//examples/imagestamping/go:go-container",
-    }
+    },
+    # K8s deployment template wtih a stamping variable to replace
+    template = ":deployment.yaml",
 )

--- a/examples/imagestamping/BUILD
+++ b/examples/imagestamping/BUILD
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,14 +11,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-set -euo pipefail
 
-function guess_runfiles() {
-    pushd ${BASH_SOURCE[0]}.runfiles > /dev/null 2>&1
-    pwd
-    popd > /dev/null 2>&1
-}
+load("@io_bazel_rules_k8s//k8s:object.bzl", "k8s_object")
 
-RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
+package(default_visibility = ["//visibility:public"])
 
-%{resolver} %{resolver_args} %{stamp_args} --template %{yaml} --image_chroot=%{image_chroot} %{images}
+licenses(["notice"])  # Apache 2.0
+
+
+k8s_object(
+    name = "image-stamping",
+    # K8s deployment template wtih a stamping variable to replace
+    template = ":deployment.yaml",
+    # Build images with the same container
+    images = {
+        "index.docker.io/parsec86/{REPOSITORY}:{STABLE_GIT_COMMIT}": "//examples/imagestamping/go:go-container",
+    }
+)

--- a/examples/imagestamping/deployment.yaml
+++ b/examples/imagestamping/deployment.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: image-stamping
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: image-stamping
+    spec:
+      containers:
+      - name: image-stamping
+        image: index.docker.io/parsec86/{REPOSITORY}:{STABLE_GIT_COMMIT}
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 50051 

--- a/examples/imagestamping/go/BUILD
+++ b/examples/imagestamping/go/BUILD
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-
 # Copyright 2017 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,14 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-set -euo pipefail
 
-function guess_runfiles() {
-    pushd ${BASH_SOURCE[0]}.runfiles > /dev/null 2>&1
-    pwd
-    popd > /dev/null 2>&1
-}
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+load("@k8s_deploy//:defaults.bzl", "k8s_deploy")
 
-RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
+package(default_visibility = ["//visibility:public"])
 
-%{resolver} %{resolver_args} %{stamp_args} --template %{yaml} --image_chroot=%{image_chroot} %{images}
+go_image(
+    name = "go-container",
+    srcs = ["main.go"],
+    importpath = "github.com/bazelbuild/not-my-project/examples/imagestamping/go",
+)

--- a/examples/imagestamping/go/BUILD
+++ b/examples/imagestamping/go/BUILD
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
-load("@k8s_deploy//:defaults.bzl", "k8s_deploy")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/examples/imagestamping/go/main.go
+++ b/examples/imagestamping/go/main.go
@@ -1,0 +1,18 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package main
+
+func main() {
+	println("hello image stamping test container")
+}

--- a/examples/imagestamping/stamp_variables
+++ b/examples/imagestamping/stamp_variables
@@ -1,0 +1,4 @@
+#!/bin/bash
+echo "STABLE_GIT_COMMIT $(git log -1 --pretty=%h --abbrev=8)"
+echo "STABLE_USER_NAME $USER"
+echo "REPOSITORY image-stamping"

--- a/k8s/object.bzl
+++ b/k8s/object.bzl
@@ -94,7 +94,7 @@ def _impl(ctx):
     stamp_inputs = [ctx.info_file, ctx.version_file]
     stamp_args = " ".join(["--stamp-info-file=%s" % _runfiles(ctx, f) for f in stamp_inputs])
     all_inputs += stamp_inputs
-    
+
     image_chroot_arg = ctx.attr.image_chroot
     image_chroot_arg = ctx.expand_make_variables("image_chroot", image_chroot_arg, {})
     if "{" in ctx.attr.image_chroot:

--- a/k8s/object.bzl
+++ b/k8s/object.bzl
@@ -93,7 +93,8 @@ def _impl(ctx):
     # files to the runfiles so they are available to the resolver executable.
     stamp_inputs = [ctx.info_file, ctx.version_file]
     stamp_args = " ".join(["--stamp-info-file=%s" % _runfiles(ctx, f) for f in stamp_inputs])
-
+    all_inputs += stamp_inputs
+    
     image_chroot_arg = ctx.attr.image_chroot
     image_chroot_arg = ctx.expand_make_variables("image_chroot", image_chroot_arg, {})
     if "{" in ctx.attr.image_chroot:
@@ -133,7 +134,7 @@ def _impl(ctx):
                 files = [
                     ctx.executable.resolver,
                     ctx.outputs.substituted,
-                ] + all_inputs + stamp_inputs,
+                ] + all_inputs,
                 transitive_files = ctx.attr.resolver[DefaultInfo].default_runfiles.files,
             ),
         ),

--- a/k8s/object.bzl
+++ b/k8s/object.bzl
@@ -90,9 +90,9 @@ def _impl(ctx):
             ])]
 
     # Add workspace_status_command files to the args that are pushed to the resolver and adds the
-    # files to the runfiles so they are available to the resolver executable. 
+    # files to the runfiles so they are available to the resolver executable.
     stamp_inputs = [ctx.info_file, ctx.version_file]
-    stamp_args = " ".join(["--stamp-info-file=%s" % _runfiles(ctx, f) for f in stamp_inputs ])
+    stamp_args = " ".join(["--stamp-info-file=%s" % _runfiles(ctx, f) for f in stamp_inputs])
 
     image_chroot_arg = ctx.attr.image_chroot
     image_chroot_arg = ctx.expand_make_variables("image_chroot", image_chroot_arg, {})
@@ -110,7 +110,7 @@ def _impl(ctx):
         },
         output = ctx.outputs.substituted,
     )
-    
+
     ctx.actions.expand_template(
         template = ctx.file._template,
         substitutions = {

--- a/k8s/resolver.py
+++ b/k8s/resolver.py
@@ -37,6 +37,10 @@ parser = argparse.ArgumentParser(
     description='Resolve image references to digests.')
 
 parser.add_argument(
+    '--stamp-info-file', action='append',
+    help='The workspace_status_command files used to resolve stamping variables')
+
+parser.add_argument(
   '--template', action='store',
   help='The template file to resolve.')
 
@@ -57,65 +61,84 @@ parser.add_argument(
 
 _THREADS = 32
 
+def _read_stamp_files(stamp_info_files):
+  """Reads the content from each of the files and appends the contents"""
+  stamps = ""
+  for filepath in stamp_info_files:
+    with open(filepath) as f:
+      content = f.read()
+      stamps += content
 
+  return stamps
+
+def _generate_stamp_info(stamp_list):
+  """Parses the string extracting out the stamp variables and values"""
+  stamp_info = {}
+
+  for stamp in stamp_list.splitlines():
+    key, value = stamp.split(" ")
+    stamp_info[key] = value
+  
+  return stamp_info
+    
 def Resolve(input, string_to_digest):
-  """Translate tag references within the input yaml into digests."""
-  def walk_dict(d):
-    return {
-      walk(k): walk(v)
-      for (k, v) in d.iteritems()
-    }
+    """Translate tag references within the input yaml into digests."""
+    def walk_dict(d):
+        return {
+            walk(k): walk(v)
+            for (k, v) in d.iteritems()
+        }
 
-  def walk_list(l):
-    return [walk(e) for e in l]
+    def walk_list(l):
+        return [walk(e) for e in l]
 
-  def walk_string(s):
-    try:
-      return string_to_digest(s)
-    except:
-      return s
+    def walk_string(s):
+        try:
+            return string_to_digest(s)
+        except:
+            return s
 
-  def walk(o):
-    if isinstance(o, dict):
-      return walk_dict(o)
-    if isinstance(o, list):
-      return walk_list(o)
-    if isinstance(o, str):
-      return walk_string(o)
-    return o
+    def walk(o):
+        if isinstance(o, dict):
+            return walk_dict(o)
+        if isinstance(o, list):
+            return walk_list(o)
+        if isinstance(o, str):
+            return walk_string(o)
+        return o
 
-  return yaml.dump_all(map(walk, yaml.load_all(input)))
+    return yaml.dump_all(map(walk, yaml.load_all(input)))
 
 
 def StringToDigest(string, overrides, transport):
-  """Turn a string into a stringified digest."""
-  if string in overrides:
-    return str(overrides[string])
+    """Turn a string into a stringified digest."""
+    if string in overrides:
+        return str(overrides[string])
 
-  # Attempt to turn the string into a tag, this may throw.
-  tag = docker_name.Tag(string)
+    # Attempt to turn the string into a tag, this may throw.
+    tag = docker_name.Tag(string)
 
-  def fully_qualify_digest(digest):
-    return docker_name.Digest('{registry}/{repo}@{digest}'.format(
-      registry=tag.registry, repo=tag.repository, digest=digest))
+    def fully_qualify_digest(digest):
+        return docker_name.Digest('{registry}/{repo}@{digest}'.format(
+            registry=tag.registry, repo=tag.repository, digest=digest))
 
-  # Resolve the tag to digest using the standard
-  # Docker keychain logic.
-  creds = docker_creds.DefaultKeychain.Resolve(tag)
-  with v2_2_image.FromRegistry(tag, creds, transport) as img:
-    if img.exists():
-      digest = fully_qualify_digest(img.digest())
-      overrides[string] = digest
-      return str(digest)
+    # Resolve the tag to digest using the standard
+    # Docker keychain logic.
+    creds = docker_creds.DefaultKeychain.Resolve(tag)
+    with v2_2_image.FromRegistry(tag, creds, transport) as img:
+        if img.exists():
+            digest = fully_qualify_digest(img.digest())
+            overrides[string] = digest
+            return str(digest)
 
-  # If the tag doesn't exists as v2.2, then try as v2.
-  with v2_image.FromRegistry(tag, creds, transport) as img:
-    digest = fully_qualify_digest(img.digest())
-    overrides[string] = digest
-    return str(digest)
+    # If the tag doesn't exists as v2.2, then try as v2.
+    with v2_image.FromRegistry(tag, creds, transport) as img:
+        digest = fully_qualify_digest(img.digest())
+        overrides[string] = digest
+        return str(digest)
 
 
-def Publish(transport, image_chroot,
+def Publish(transport, image_chroot, stamp_info = {},
             name=None, tarball=None, config=None, digest=None, layer=None):
   if not name:
     raise Exception('Expected "name" kwarg')
@@ -143,12 +166,14 @@ def Publish(transport, image_chroot,
     digest = []
     layer = []
 
+  resolved_name = name.format(**stamp_info)
   name_to_replace = name
+
   if image_chroot:
-    name_to_publish = docker_name.Tag(os.path.join(image_chroot, name), strict=False)
+    name_to_publish = docker_name.Tag(os.path.join(image_chroot, resolved_name), strict=False)
   else:
     # Without a chroot, the left-hand-side must be a valid tag.
-    name_to_publish = docker_name.Tag(name, strict=False)
+    name_to_publish = docker_name.Tag(resolved_name, strict=False)
 
   # Resolve the appropriate credential to use based on the standard Docker
   # client logic.
@@ -159,7 +184,7 @@ def Publish(transport, image_chroot,
                              legacy_base=tarball) as v2_2_img:
       session.upload(v2_2_img)
 
-      return (name_to_replace, docker_name.Digest('{repository}@{digest}'.format(
+      return (name_to_replace, str(name_to_publish), docker_name.Digest('{repository}@{digest}'.format(
           repository=name_to_publish.as_repository(),
           digest=v2_2_img.digest())))
 
@@ -171,13 +196,18 @@ def main():
 
   unseen_strings = set()
   overrides = {}
+
+  # generate stamp info from workspace_status_files
+  stamp_files = _read_stamp_files(args.stamp_info_file)
+  stamp_info = _generate_stamp_info(stamp_files)
+
   # TODO(mattmoor): Execute these in a threadpool and
   # aggregate the results as they complete.
   for spec in args.image_spec or []:
     parts = spec.split(';')
     kwargs = dict([x.split('=', 2) for x in parts])
     try:
-      (tag, digest) = Publish(transport, args.image_chroot, **kwargs)
+      (tag, published_tag, digest) = Publish(transport, args.image_chroot, stamp_info, **kwargs)
       overrides[tag] = digest
       unseen_strings.add(tag)
     except Exception as e:

--- a/k8s/resolver.py
+++ b/k8s/resolver.py
@@ -77,6 +77,9 @@ def _generate_stamp_info(stamp_list):
 
   for stamp in stamp_list.splitlines():
     key, value = stamp.split(" ")
+    if key in stamp_info:
+      print ("WARNING: Duplicate value for workspace status key '%s': "
+              "using '%s'" % (key, value))
     stamp_info[key] = value
   
   return stamp_info


### PR DESCRIPTION
This addresses issue #378 

Adds support for using stamp variables for the repository tag so that it will resolve the repository name and tag prior to pushing the container to the repository. It now works similar to the docker_rules `push_container` rule.

```python
k8s_object(
    name = "image-stamping",
    # K8s deployment template wtih a stamping variable to replace
    template = ":deployment.yaml",
    # Build images with the same container
    images = {
        "index.docker.io/parsec86/{REPOSITORY}:{STABLE_GIT_COMMIT}": "//examples/imagestamping/go:go-container",
    }
)
```

>**Note** - Stamping only effects the resolved image name that is pushed to the container registry. The container digest will still be used inside your resolved template since the digest is immutable.