### PR TITLE
performance improvements for rules_k8s

### DIFF
--- a/k8s/object.bzl
+++ b/k8s/object.bzl
@@ -135,16 +135,13 @@ def _impl(ctx):
 
 def _resolve(ctx, string, output):
     stamps = [ctx.info_file, ctx.version_file]
-    stamp_args = [
-        "--stamp-info-file=%s" % sf.path
-        for sf in stamps
-    ]
+    args = ctx.actions.args()
+    args.add_all(stamps, format_each = "--stamp-info-file=%s")
+    args.add(string, format = "--format=%s")
+    args.add(output, format = "--output=%s")
     ctx.actions.run(
         executable = ctx.executable._stamper,
-        arguments = [
-            "--format=%s" % string,
-            "--output=%s" % output.path,
-        ] + stamp_args,
+        arguments = [args],
         inputs = stamps,
         tools = [ctx.executable._stamper],
         outputs = [output],
@@ -196,6 +193,7 @@ def _common_impl(ctx):
         kubeconfig_arg = ""
 
     kubectl_tool_info = ctx.toolchains["@io_bazel_rules_k8s//toolchains/kubectl:toolchain_type"].kubectlinfo
+    extrafiles = depset()
     if kubectl_tool_info.tool_path == "" and not kubectl_tool_info.tool_target:
         # If tool_path is empty and tool_target is None then there is no local
         # kubectl tool, we will just print a nice error message if the user
@@ -208,7 +206,7 @@ def _common_impl(ctx):
         kubectl_tool = kubectl_tool_info.tool_path
         if kubectl_tool_info.tool_target:
             kubectl_tool = _runfiles(ctx, kubectl_tool_info.tool_target.files.to_list()[0])
-            files += kubectl_tool_info.tool_target.files.to_list()
+            extrafiles = depset(transitive = kubectl_tool_info.tool_target.files)
 
         substitutions = {
             "%{cluster}": cluster_arg,
@@ -223,12 +221,12 @@ def _common_impl(ctx):
         if hasattr(ctx.executable, "resolved"):
             substitutions["%{resolve_script}"] = _runfiles(ctx, ctx.executable.resolved)
             files += [ctx.executable.resolved]
-            files += list(ctx.attr.resolved[DefaultInfo].default_runfiles.files.to_list())
+            extrafiles = depset(transitive = [ctx.attr.resolved[DefaultInfo].default_runfiles.files, extrafiles])
 
         if hasattr(ctx.executable, "reversed"):
             substitutions["%{reverse_script}"] = _runfiles(ctx, ctx.executable.reversed)
             files += [ctx.executable.reversed]
-            files += list(ctx.attr.reversed[DefaultInfo].default_runfiles.files.to_list())
+            extrafiles = depset(transitive = [ctx.attr.reversed[DefaultInfo].default_runfiles.files, extrafiles])
 
         if hasattr(ctx.files, "unresolved"):
             substitutions["%{unresolved}"] = _runfiles(ctx, ctx.file.unresolved)
@@ -242,7 +240,7 @@ def _common_impl(ctx):
 
     return [
         DefaultInfo(
-            runfiles = ctx.runfiles(files = files),
+            runfiles = ctx.runfiles(files = files, transitive_files = extrafiles),
         ),
     ]
 


### PR DESCRIPTION
https://docs.bazel.build/versions/master/skylark/performance.html#use-ctxactionsargs-for-command-lines

Reduce usage of to_list in depsets and use ctx.actions.args instead of args list