### PR TITLE
Use go-containerregistry API that supports schema 1 images in resolver

### DIFF
--- a/k8s/go/cmd/resolver/resolver.go
+++ b/k8s/go/cmd/resolver/resolver.go
@@ -230,15 +230,11 @@ func resolveString(r *resolver, s string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("unable to get the authenticator using the default keychain for image %v: %v", t, auth)
 	}
-	img, err := remote.Image(t, remote.WithAuth(auth))
+	desc, err := remote.Get(t, remote.WithAuth(auth))
 	if err != nil {
 		return "", fmt.Errorf("unable to get image %v from registry: %v", t, err)
 	}
-	d, err := img.Digest()
-	if err != nil {
-		return "", fmt.Errorf("unable to get digest for image %v: %v", t, err)
-	}
-	resolved := fmt.Sprintf("%s/%s@%v", t.Context().RegistryStr(), t.Context().RepositoryStr(), d)
+	resolved := fmt.Sprintf("%s/%s@%v", t.Context().RegistryStr(), t.Context().RepositoryStr(), desc.Digest)
 	r.resolvedImages[s] = resolved
 	return resolved, nil
 }

--- a/k8s/object.bzl
+++ b/k8s/object.bzl
@@ -229,7 +229,7 @@ def _common_impl(ctx):
         kubectl_tool = kubectl_tool_info.tool_path
         if kubectl_tool_info.tool_target:
             kubectl_tool = _runfiles(ctx, kubectl_tool_info.tool_target.files.to_list()[0])
-            extrafiles = depset(transitive = kubectl_tool_info.tool_target.files)
+            extrafiles = depset(transitive = [kubectl_tool_info.tool_target.files])
 
         substitutions = {
             "%{cluster}": cluster_arg,


### PR DESCRIPTION
#433 The resolver should be able to pull `quay.io/coreos/prometheus-operator:v0.29.0` now. I verified this locally.