### PR TITLE
Make //k8s:reverser and //k8s:stamper PY2 and PY3 compatible

### DIFF
--- a/k8s/BUILD
+++ b/k8s/BUILD
@@ -33,7 +33,6 @@ par_binary(
     name = "stamper",
     srcs = ["stamper.py"],
     main = "stamper.py",
-    python_version = "PY2",
     visibility = ["//visibility:public"],
 )
 
@@ -41,9 +40,9 @@ par_binary(
     name = "reverser",
     srcs = ["reverser.py"],
     main = "reverser.py",
-    python_version = "PY2",
     visibility = ["//visibility:public"],
-    deps = [
-        "@com_github_yaml_pyyaml//:yaml",
-    ],
+    deps = select({
+        "@bazel_tools//tools/python:PY2": ["@com_github_yaml_pyyaml//:yaml"],
+        "@bazel_tools//tools/python:PY3": ["@com_github_yaml_pyyaml//:yaml3"],
+    }),
 )

--- a/k8s/k8s.bzl
+++ b/k8s/k8s.bzl
@@ -36,10 +36,20 @@ py_library(
         "lib",
     ],
     visibility = ["//visibility:public"],
-)""",
-            sha256 = "6b4314b1b2051ddb9d4fcd1634e1fa9c1bb4012954273c9ff3ef689f6ec6c93e",
-            strip_prefix = "pyyaml-3.12",
-            urls = ["https://github.com/yaml/pyyaml/archive/3.12.zip"],
+)
+
+py_library(
+    name = "yaml3",
+    srcs = glob(["lib3/yaml/*.py"]),
+    imports = [
+        "lib3",
+    ],
+    visibility = ["//visibility:public"],
+)
+""",
+            sha256 = "e9df8412ddabc9c21b4437ee138875b95ebb32c25f07f962439e16005152e00e",
+            strip_prefix = "pyyaml-5.1.2",
+            urls = ["https://github.com/yaml/pyyaml/archive/5.1.2.zip"],
         )
 
     # Register the default kubectl toolchain targets for supported platforms

--- a/k8s/reverser.py
+++ b/k8s/reverser.py
@@ -32,7 +32,7 @@ def main():
   with open(args.template, 'r') as f:
     inputs = f.read()
 
-  content = yaml.dump_all(reversed([x for x in yaml.load_all(inputs)]))
+  content = yaml.dump_all(reversed([x for x in yaml.load_all(inputs, Loader=yaml.SafeLoader)]))
 
   print(content)
 


### PR DESCRIPTION
* Upgrade PyYAML to 5.1.2
* Select the PY2 or PY3 version of PyYAML depending on the desired PY version

I've been testing this downstream, and have confirmed that rules such as `.delete` works with both `--host_force_python=PY3` and `--host_force_python=PY2`.

