### PR TITLE
Remove PY2 notice from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,17 +41,6 @@ load("@io_bazel_rules_k8s//k8s:k8s_go_deps.bzl", k8s_go_deps = "deps")
 k8s_go_deps()
 ```
 
-NEW: Starting with Bazel 0.27.0, you also need to add to your .bazelrc
-file the following:
-
-```
-build --host_force_python=PY2
-test --host_force_python=PY2
-run --host_force_python=PY2
-```
-See https://github.com/bazelbuild/rules_docker/issues/842 for more
-details.
-
 ## Kubernetes Authentication
 
 As is somewhat standard for Bazel, the expectation is that the
@@ -754,4 +743,3 @@ Here's a (non-exhaustive) list of companies that use `rules_k8s` in production. 
   * [Etsy](https://www.etsy.com)
   * [Jetstack](https://www.jetstack.io/)
   * [Prow](https://github.com/kubernetes/test-infra/tree/master/prow)
-


### PR DESCRIPTION
This is no longer necessary since the resolver was migrated (released in 0.3.0), and #461 (not yet released).