### PR TITLE
propagate error message up the stack

### DIFF
--- a/k8s/go/cmd/resolver/resolver.go
+++ b/k8s/go/cmd/resolver/resolver.go
@@ -182,7 +182,7 @@ func publish(spec []imageSpec, stamper *compat.Stamper) (map[string]string, map[
 	for _, s := range spec {
 		digestRef, err := publishSingle(s, stamper)
 		if err != nil {
-			return nil, nil, fmt.Errorf("unable to publish image %s", s.name)
+			return nil, nil, err
 		}
 		overrides[s.name] = digestRef
 		unseen[s.name] = true


### PR DESCRIPTION
I spent a while troubleshooting an issue based on an error message that didn't show the underlying cause.  I thought variables were not being substituted correctly but instead it was something unrelated.

Error message prior to the change:
```
2020/01/02 13:08:17 Unable to publish images: unable to publish image docker-registry/docker-repo:{STABLE_GIT_COMMIT}
```

Error message after the change:
```
2020/01/02 13:08:17 Unable to publish images: unable to push image docker-registry/docker-repo:323fde312207a0b5d67c7a0326833a94dd54e0bd: TAG_INVALID: The image tag '323fde312207a0b5d67c7a0326833a94dd54e0bd' already exists in the 'docker-repo' repository and cannot be overwritten because the repository is immutable.
```

I'm not sure if this is the best way to propagate the error but it clears up the underlying cause.