### PR TITLE
Modify description of k8s_object to be more explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ A rule for interacting with Kubernetes objects.
       <td>
         <p><code>Kind, required</code></p>
         <p>The kind of the Kubernetes object in the yaml.</p>
-        <p><b>If this is omitted, the <code>create, replace, delete,
+        <p><b>If this is omitted, the <code>apply, create, replace, delete,
           describe</code> actions will not exist.</b></p>
       </td>
     </tr>
@@ -447,7 +447,7 @@ A rule for interacting with Kubernetes objects.
         <p><code>string, optional</code></p>
         <p>The name of the cluster to which <code>create, replace, delete,
           describe</code> should speak. Subject to "Make" variable substitution.</p>
-        <p><b>If this is omitted, the <code>create, replace, delete,
+        <p><b>If this is omitted, the <code>apply, create, replace, delete,
           describe</code> actions will not exist.</b></p>
       </td>
     </tr>


### PR DESCRIPTION
Small fix but changed the doc to be explicit on the unavailable options when `kind` or `cluster` are omitted.