### PR TITLE
Fix the documentation bug on stamping

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ by leveraging `--workspace_status_command`.  One pattern for this is to check in
 the following:
 ```shell
 $ cat .bazelrc
-build --workspace_status_command=./print-workspace-status.sh
+build --workspace_status_command="bash ./print-workspace-status.sh"
 
 $ cat print-workspace-status.sh
 cat <<EOF


### PR DESCRIPTION
I run the bazel with `--workspace_status_command` to stamp the values such as GCP project id, GCR repository name, GKE cluster name and so on, and I passed the path to the shellscript as written on README.

However it got error saying "command not found"

```
$ bazel run //:gke_deploy --verbose_failures
INFO: Analyzed target //:gke_deploy (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
ERROR: Process exited with status 127
/bin/sh: variables.sh: command not found
Target //:gke_deploy failed to build
INFO: Elapsed time: 0.381s, Critical Path: 0.06s
INFO: 0 processes.
FAILED: Build did NOT complete successfully
FAILED: Build did NOT complete successfully

$ cat .bazerlrc
run --workspace_status_command=./variables.sh
```

I found the exact discussion around this on bazelbuild/bazel#5002. The issue says that `--workspace_status_command` doesn't accept shellscript was **bug** at first, and then in the middle of discussion, it was closed. In the thread, some workarounds were proposed but they were not reflected to this repo's README. At least, the description as-is doesn't work, so I'm requesting the fix.

P.S. to the referred bug (bazelbuild/bazel#5002):
I understand the path expression is not platform independent, but stamping itself isn't neither and when we add the lines in `.bazelrc` we can put platform dependent sections so I don't think not accepting Linux relative path 