### PR TITLE
Fix version used in README to v0.4 (current latest)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 # This requires rules_docker to be fully instantiated before
 # it is pulled in.
-# Download the rules_k8s repository at release v0.3.1
+# Download the rules_k8s repository at release v0.4
 http_archive(
     name = "io_bazel_rules_k8s",
-    sha256 = "cc75cf0d86312e1327d226e980efd3599704e01099b58b3c2fc4efe5e321fcd9",
-    strip_prefix = "rules_k8s-0.3.1",
-    urls = ["https://github.com/bazelbuild/rules_k8s/releases/download/v0.3.1/rules_k8s-v0.3.1.tar.gz"],
+    sha256 = "d91aeb17bbc619e649f8d32b65d9a8327e5404f451be196990e13f5b7e2d17bb",
+    strip_prefix = "rules_k8s-0.4",
+    urls = ["https://github.com/bazelbuild/rules_k8s/releases/download/v0.4/rules_k8s-v0.4.tar.gz],
 )
 
 load("@io_bazel_rules_k8s//k8s:k8s.bzl", "k8s_repositories")

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ http_archive(
     name = "io_bazel_rules_k8s",
     sha256 = "d91aeb17bbc619e649f8d32b65d9a8327e5404f451be196990e13f5b7e2d17bb",
     strip_prefix = "rules_k8s-0.4",
-    urls = ["https://github.com/bazelbuild/rules_k8s/releases/download/v0.4/rules_k8s-v0.4.tar.gz],
+    urls = ["https://github.com/bazelbuild/rules_k8s/releases/download/v0.4/rules_k8s-v0.4.tar.gz"],
 )
 
 load("@io_bazel_rules_k8s//k8s:k8s.bzl", "k8s_repositories")


### PR DESCRIPTION
The current latest is v0.4 whereas README still uses v0.3.1. Even thought it is an example snippet, it's more developer friendly to provide the copy-n-paste-able snippet. In that sense, changed the version used in the snippet.

I checked up the hash on my local machine but if the value is incorrect, I would like to have the correct value on the review time.

```
$ openssl sha256 rules_k8s-v0.4.tar.gz
SHA256(rules_k8s-v0.4.tar.gz)= d91aeb17bbc619e649f8d32b65d9a8327e5404f451be196990e13f5b7e2d17bb
```