### PR TITLE
Add descriptions on `resolver_args`

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,7 +572,7 @@ A rule for interacting with Kubernetes objects.
       <td>
         <p><code>string_list, optional</code></p>
         <p>Additional arguments to pass to the resolver directly.</p>
-        <p>NOTE: This option is to pass the specific arguments to the resolver directly, such as <pre>--allow_unused_images</pre>.</p>
+        <p>NOTE: This option is to pass the specific arguments to the resolver directly, such as <code>--allow_unused_images</code>.</p>
       </td>
     </tr>
   </tbody>

--- a/README.md
+++ b/README.md
@@ -567,6 +567,14 @@ A rule for interacting with Kubernetes objects.
         <p>NOTE: Not all options are available for all kubectl commands. To view the list of global options run: <code>kubectl options</code></p>
       </td>
     </tr>
+    <tr>
+      <td><code>resolver_args</code></td>
+      <td>
+        <p><code>string_list, optional</code></p>
+        <p>Additional arguments to pass to the resolver directly.</p>
+        <p>NOTE: This option is to pass the specific arguments to the resolver directly, such as <pre>--allow_unused_images</pre>.</p>
+      </td>
+    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
In #161 and #162, the attribution `resolver_args` was added to `k8s_object`, but the attribute was not documented. As described in the doc, some options such as `--allow_unused_images` should be passed via this option.