### PR TITLE
Install an old version of bazel in gcloud-bazel.

### DIFF
--- a/images/gcloud-bazel/Dockerfile
+++ b/images/gcloud-bazel/Dockerfile
@@ -14,7 +14,10 @@
 
 # Ubuntu with bazel, gcloud and its dependencies preinstalled.
 
-FROM launcher.gcr.io/google/bazel:latest
+ARG NEW_VERSION
+ARG OLD_VERSION
+FROM launcher.gcr.io/google/bazel:$(OLD_VERSION) as old
+FROM launcher.gcr.io/google/bazel:$(NEW_VERSION)
 # Based off github.com/kubernetes/test-infra/images/bazelbuild
 LABEL maintainer="fejta@google.com"
 
@@ -41,3 +44,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python-pip \
     && apt-get clean \
     && python -m pip install --upgrade pip setuptools wheel
+
+ARG OLD_VERSION
+COPY --from=old \
+  /usr/local/lib/bazel/bin/bazel-real /usr/local/lib/bazel/bin/bazel-${OLD_VERSION}

--- a/images/gcloud-bazel/Makefile
+++ b/images/gcloud-bazel/Makefile
@@ -15,6 +15,8 @@
 PROJECT ?= rules-k8s
 # gcr.io/rule-k8s/gcloud-bazel by default
 IMG = gcr.io/$(PROJECT)/gcloud-bazel
+OLD ?= 2.2.0
+NEW ?= 3.0.0
 TAG := $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
 
 build:
@@ -23,7 +25,7 @@ build:
 push:
 	gcloud builds submit \
 		--config=cloudbuild.yaml \
-		--substitutions=_IMG=$(IMG),_USER=$(USER),SHORT_SHA=$(TAG) \
+		--substitutions=_IMG=$(IMG),_USER=$(USER),SHORT_SHA=$(TAG),_NEW_VERSION=$(NEW),_OLD_VERSION=$(OLD) \
 		--project=$(PROJECT) \
 		.
 

--- a/images/gcloud-bazel/cloudbuild.yaml
+++ b/images/gcloud-bazel/cloudbuild.yaml
@@ -13,26 +13,30 @@
 # limitations under the License.
 
 steps:
-- name: 'gcr.io/cloud-builders/docker'
-  args: [
-    'build',
-    '--pull',
-    '--label=gcb-id=${BUILD_ID}',
-    '--label=git-short=${SHORT_SHA}',
-    '--label=git-full=${COMMIT_SHA}',
-    '-t',
-    '${_IMG}:${SHORT_SHA}',
-    '.',
-  ]
-- name: 'gcr.io/cloud-builders/docker'
-  args: ['tag', '${_IMG}:${SHORT_SHA}', '${_IMG}:latest']
-- name: 'gcr.io/cloud-builders/docker'
-  args: ['tag', '${_IMG}:${SHORT_SHA}', '${_IMG}:latest-${_USER}']
+- name: gcr.io/cloud-builders/docker
+  args:
+  - build
+  - --pull
+  - --label=gcb-id=${BUILD_ID}
+  - --label=git-short=${SHORT_SHA}
+  - --label=git-full=${COMMIT_SHA}
+  - --tag=${_IMG}:${SHORT_SHA}
+  - --build-arg=NEW_VERSION=$_NEW_VERSION
+  - --build-arg=OLD_VERSION=$_OLD_VERSION
+  - .
+- name: gcr.io/cloud-builders/docker
+  args:
+  - tag
+  - ${_IMG}:${SHORT_SHA}
+  - ${_IMG}:latest
+  - ${_IMG}:latest-${_USER}
 
 substitutions:
-  _IMG: 'gcr.io/${PROJECT_ID}/gcloud-bazel'
+  _IMG: gcr.io/${PROJECT_ID}/gcloud-bazel
+  _NEW_VERSION: 3.0.0
+  _OLD_VERSION: 2.2.0
 
 images:
-- '${_IMG}:latest'
-- '${_IMG}:latest-${_USER}'
-- '${_IMG}:${SHORT_SHA}'
+- ${_IMG}:latest
+- ${_IMG}:latest-${_USER}
+- ${_IMG}:${SHORT_SHA}


### PR DESCRIPTION
This will allow CI to choose between those two versions via a .bazelversion file