### PR TITLE
Add a ".resolve" alias for the resolve task

### DIFF
--- a/examples/hellogrpc/e2e-test.sh
+++ b/examples/hellogrpc/e2e-test.sh
@@ -63,6 +63,11 @@ apply-lb() {
     logfail bazel-bin/examples/hellogrpc/staging-service.apply
 }
 
+resolve() {
+    logfail bazel build "examples/hellogrpc/$1/server:staging.resolve"
+    logfail "bazel-bin/examples/hellogrpc/$1/server/staging.resolve"
+}
+
 create() {
     logfail bazel build "examples/hellogrpc/$1/server:staging.create"
     logfail "bazel-bin/examples/hellogrpc/$1/server/staging.create"
@@ -182,6 +187,7 @@ main() {
         local want
         want="$RANDOM"
         edit "$lang" "$want"
+        resolve "$lang"
         create "$lang"
         sleep 25
         check_msg "$lang" "$want"

--- a/examples/hellohttp/e2e-test.sh
+++ b/examples/hellohttp/e2e-test.sh
@@ -85,6 +85,10 @@ edit() {
     logfail "./examples/hellohttp/$1/edit.sh" "$2"
 }
 
+resolve() {
+    logfail bazel run "examples/hellohttp/$1:staging.resolve"
+}
+
 apply() {
     logfail bazel run "examples/hellohttp/$1:staging.apply"
 }
@@ -148,6 +152,7 @@ main() {
         trap "echo hellohttp/$lang: FAIL >&2" EXIT
         for want in $RANDOM $RANDOM; do
           edit "$lang" "$want"
+          resolve "$lang"
           apply "$lang"
           sleep 25s
           check_msg "$want"

--- a/k8s/object.bzl
+++ b/k8s/object.bzl
@@ -517,6 +517,7 @@ def k8s_object(name, **kwargs):
     kwargs["image_target_strings"] = _deduplicate(kwargs.get("images", {}).values())
 
     _k8s_object(name = name, **kwargs)
+    _k8s_object(name = name + ".resolve", **kwargs)
     _reversed(
         name = name + ".reversed",
         substituted = name,

--- a/k8s/objects.bzl
+++ b/k8s/objects.bzl
@@ -95,6 +95,7 @@ def k8s_objects(name, objects, **kwargs):
     # TODO(mattmoor): We may have to normalize the labels that come
     # in through objects.
     _run_all(name = name, objects = _cmd_objects("", objects), delimiter = "echo ---\n", **kwargs)
+    _run_all(name = name + ".resolve", objects = _cmd_objects("", objects), delimiter = "echo ---\n", **kwargs)
     _run_all(name = name + ".create", objects = _cmd_objects(".create", objects), **kwargs)
     _run_all(name = name + ".delete", objects = _cmd_objects(".delete", objects, True), **kwargs)
     _run_all(name = name + ".replace", objects = _cmd_objects(".replace", objects), **kwargs)


### PR DESCRIPTION
When automating interactions with the outputs of a k8s_object, it's easy to find and operate on tasks like ".apply" because there is a sigil (literally, ".apply") that you can search for in the target output. Because there is no corresponding sigil for the "resolve" target it's difficult to filter for this task.

Looking for the absence of "apply", "delete", etc is not very future-proof, since other target types could be introduced. Filtering out targets that contain a period between the colon and the newline is restrictive on target names.

I believe this is would achieve the desired effect.