### PR TITLE
Add .diff target

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,18 @@ Users can "describe" their environment by running:
 bazel run :dev.describe
 ```
 
+### Diff
+
+Users can "diff" a configuration by running:
+```shell
+bazel run :dev.diff
+```
+
+`:dev.diff` maps to `kubectl diff`, which will diff the live against the would-be applied version.
+For more information see the `kubectl` documentation.
+
+This diffs the **resolved** template, but does not include republishing images.
+
 <a name="k8s_object"></a>
 ## k8s_object
 

--- a/examples/hellogrpc/e2e-test.sh
+++ b/examples/hellogrpc/e2e-test.sh
@@ -121,6 +121,11 @@ edit() {
     logfail "./examples/hellogrpc/$1/server/edit.sh" "$2"
 }
 
+diff() {
+    logfail bazel build "examples/hellogrpc/$1/server:staging.diff"
+    logfail "bazel-bin/examples/hellogrpc/$1/server/staging.diff"
+}
+
 update() {
     logfail bazel build "examples/hellogrpc/$1/server:staging.replace"
     logfail "bazel-bin/examples/hellogrpc/$1/server/staging.replace"
@@ -193,6 +198,7 @@ main() {
         check_msg "$lang" "$want"
         want="$RANDOM"
         edit "$lang" "$want"
+        diff "$lang"
         update "$lang"
         sleep 25 # Mitigate against slow startup
         check_msg "$lang" "$want"

--- a/examples/hellogrpc/e2e-test.sh
+++ b/examples/hellogrpc/e2e-test.sh
@@ -59,6 +59,9 @@ function EXPECT_CONTAINS_PATTERN() {
 
 # Ensure there is an ip address for hell-grpc-staging:50051
 apply-lb() {
+    # We use `bazel build ... && bazel-bin/...` here in this file instead of
+    # `bazel run` directly in order to make sure that direct execution of the
+    # built output works as well
     logfail bazel build examples/hellogrpc:staging-service.apply
     logfail bazel-bin/examples/hellogrpc/staging-service.apply
 }

--- a/examples/hellogrpc/e2e-test.sh
+++ b/examples/hellogrpc/e2e-test.sh
@@ -126,7 +126,24 @@ edit() {
 
 diff() {
     logfail bazel build "examples/hellogrpc/$1/server:staging.diff"
-    logfail "bazel-bin/examples/hellogrpc/$1/server/staging.diff"
+    # We want diff to return 1 so we can't use logfail here
+    cmd="bazel-bin/examples/hellogrpc/$1/server/staging.diff"
+    echo "++ $cmd"
+    local out
+    local code
+    out=$("$cmd" 2>&1) && code=0 || code=$?
+    if [ $code -eq 1 ]; then
+        return 0
+    elif [ $code -eq 0 ]; then
+        echo "++ DIFF FOUND NO CHANGES: $cmd" >&2
+        echo "$out"
+        # We can't just return $code here, since it would be a "success"
+        return 1
+    else
+    echo "++ FAIL: $code=$cmd" >&2
+    echo "$out"
+    return $code
+    logfail
 }
 
 update() {

--- a/examples/hellogrpc/e2e-test.sh
+++ b/examples/hellogrpc/e2e-test.sh
@@ -143,7 +143,6 @@ diff() {
     echo "++ FAIL: $code=$cmd" >&2
     echo "$out"
     return $code
-    logfail
 }
 
 update() {

--- a/examples/hellogrpc/e2e-test.sh
+++ b/examples/hellogrpc/e2e-test.sh
@@ -140,9 +140,10 @@ diff() {
         # We can't just return $code here, since it would be a "success"
         return 1
     else
-    echo "++ FAIL: $code=$cmd" >&2
-    echo "$out"
-    return $code
+        echo "++ FAIL: $code=$cmd" >&2
+        echo "$out"
+        return $code
+    fi
 }
 
 update() {

--- a/examples/hellohttp/e2e-test.sh
+++ b/examples/hellohttp/e2e-test.sh
@@ -89,6 +89,10 @@ resolve() {
     logfail bazel run "examples/hellohttp/$1:staging.resolve"
 }
 
+diff() {
+    logfail bazel run "examples/hellohttp/$1:staging.diff"
+}
+
 apply() {
     logfail bazel run "examples/hellohttp/$1:staging.apply"
 }
@@ -153,6 +157,7 @@ main() {
         for want in $RANDOM $RANDOM; do
           edit "$lang" "$want"
           resolve "$lang"
+          diff "$lang"
           apply "$lang"
           sleep 25s
           check_msg "$want"

--- a/examples/hellohttp/e2e-test.sh
+++ b/examples/hellohttp/e2e-test.sh
@@ -107,9 +107,10 @@ diff() {
         # We can't just return $code here, since it would be a "success"
         return 1
     else
-    echo "++ FAIL: $code=$cmd" >&2
-    echo "$out"
-    return $code
+        echo "++ FAIL: $code=$cmd" >&2
+        echo "$out"
+        return $code
+    fi
 }
 
 apply() {

--- a/examples/hellohttp/e2e-test.sh
+++ b/examples/hellohttp/e2e-test.sh
@@ -90,9 +90,6 @@ resolve() {
 }
 
 diff() {
-    logfail bazel run "examples/hellohttp/$1:staging.diff"
-}
-diff() {
     # We don't want to confuse bazel build failures with diff output so we
     # need to build first
     logfail bazel build "examples/hellohttp/$1:staging.diff"
@@ -113,7 +110,6 @@ diff() {
     echo "++ FAIL: $code=$cmd" >&2
     echo "$out"
     return $code
-    logfail
 }
 
 apply() {

--- a/examples/hellohttp/e2e-test.sh
+++ b/examples/hellohttp/e2e-test.sh
@@ -92,6 +92,29 @@ resolve() {
 diff() {
     logfail bazel run "examples/hellohttp/$1:staging.diff"
 }
+diff() {
+    # We don't want to confuse bazel build failures with diff output so we
+    # need to build first
+    logfail bazel build "examples/hellohttp/$1:staging.diff"
+    # We want diff to return 1 so we can't use logfail here
+    cmd="bazel-bin/examples/hellohttp/$1/staging.diff"
+    echo "++ $cmd"
+    local out
+    local code
+    out=$("$cmd" 2>&1) && code=0 || code=$?
+    if [ $code -eq 1 ]; then
+        return 0
+    elif [ $code -eq 0 ]; then
+        echo "++ DIFF FOUND NO CHANGES: $cmd" >&2
+        echo "$out"
+        # We can't just return $code here, since it would be a "success"
+        return 1
+    else
+    echo "++ FAIL: $code=$cmd" >&2
+    echo "$out"
+    return $code
+    logfail
+}
 
 apply() {
     logfail bazel run "examples/hellohttp/$1:staging.apply"

--- a/k8s/BUILD
+++ b/k8s/BUILD
@@ -27,6 +27,7 @@ exports_files([
     "reverse.sh.tpl",
     "delete.sh.tpl",
     "describe.sh.tpl",
+    "diff.sh.tpl",
 ])
 
 par_binary(

--- a/k8s/diff.sh.tpl
+++ b/k8s/diff.sh.tpl
@@ -21,6 +21,10 @@ function guess_runfiles() {
     popd > /dev/null 2>&1
 }
 
+function exe() { echo "\$ ${@/eval/}" ; "$@" ; }
+
 RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"
 
-%{resolver} %{resolver_args} %{stamp_args} --template %{yaml} --image_chroot=%{image_chroot} --substitutions=%{substitutions} %{images} $@
+PYTHON_RUNFILES="${RUNFILES}" %{resolve_script} --no_push | \
+  exe  %{kubectl_tool} --kubeconfig="%{kubeconfig}" --cluster="%{cluster}" \
+  --context="%{context}" --user="%{user}" %{namespace_arg} diff $@ -f -

--- a/k8s/go/cmd/resolver/resolver.go
+++ b/k8s/go/cmd/resolver/resolver.go
@@ -37,6 +37,7 @@ var (
 	k8sTemplate       = flag.String("template", "", "The k8s YAML template file to resolve.")
 	substitutionsFile = flag.String("substitutions", "", "A file with a list of substitutions that were made in the YAML template. Any stamp values that appear are stamped by the resolver.")
 	allowUnusedImages = flag.Bool("allow_unused_images", false, "Allow images that don't appear in the JSON. This is useful when generating multiple SKUs of a k8s_object, only some of which use a particular image.")
+	noPush            = flag.Bool("no_push", false, "Don't push images after resolving digests.")
 	stampInfoFile     utils.ArrayStringFlags
 	imgSpecs          utils.ArrayStringFlags
 )
@@ -185,8 +186,10 @@ func publishSingle(spec imageSpec, stamper *compat.Stamper) (string, error) {
 		return "", fmt.Errorf("unable to get authenticator for image %v", ref.Name())
 	}
 
-	if err := remote.Write(ref, img, remote.WithAuth(auth)); err != nil {
-		return "", fmt.Errorf("unable to push image %v: %v", ref.Name(), err)
+	if !*noPush {
+		if err := remote.Write(ref, img, remote.WithAuth(auth)); err != nil {
+			return "", fmt.Errorf("unable to push image %v: %v", ref.Name(), err)
+		}
 	}
 
 	d, err := img.Digest()

--- a/k8s/object.bzl
+++ b/k8s/object.bzl
@@ -508,7 +508,7 @@ def k8s_object(name, **kwargs):
         **implicit_args
     )
 
-    resolve_args = dict(**kwargs)
+    resolve_args = dict(kwargs)
     if "args" in resolve_args:
         resolve_args.pop("args")
 

--- a/k8s/object.bzl
+++ b/k8s/object.bzl
@@ -509,7 +509,8 @@ def k8s_object(name, **kwargs):
     )
 
     resolve_args = dict(**kwargs)
-    resolve_args.pop("args")
+    if "args" in resolve_args:
+        resolve_args.pop("args")
 
     _k8s_object(name = name, **resolve_args)
     _k8s_object(name = name + ".resolve", **resolve_args)

--- a/k8s/object.bzl
+++ b/k8s/object.bzl
@@ -435,6 +435,26 @@ _k8s_object_delete = rule(
     implementation = _common_impl,
 )
 
+_k8s_object_diff = rule(
+    attrs = _add_dicts(
+        {
+            "resolved": attr.label(
+                cfg = "target",
+                executable = True,
+                allow_files = True,
+            ),
+            "_template": attr.label(
+                default = Label("//k8s:diff.sh.tpl"),
+                allow_single_file = True,
+            ),
+        },
+        _common_attrs,
+    ),
+    executable = True,
+    toolchains = ["@io_bazel_rules_k8s//toolchains/kubectl:toolchain_type"],
+    implementation = _common_impl,
+)
+
 # See "attrs" parameter at https://docs.bazel.build/versions/master/skylark/lib/globals.html#parameters-26
 _implicit_attrs = [
     "visibility",
@@ -511,6 +531,18 @@ def k8s_object(name, **kwargs):
             name = name + ".apply",
             resolved = name,
             **common_args
+        )
+        _k8s_object_diff(
+            name = name + ".diff",
+            resolved = name,
+            kind = kwargs.get("kind"),
+            cluster = kwargs.get("cluster"),
+            context = kwargs.get("context"),
+            kubeconfig = kwargs.get("kubeconfig"),
+            user = kwargs.get("user"),
+            namespace = kwargs.get("namespace"),
+            args = kwargs.get("args"),
+            **implicit_args
         )
         if "kind" in kwargs:
             _k8s_object_describe(

--- a/k8s/object.bzl
+++ b/k8s/object.bzl
@@ -508,8 +508,11 @@ def k8s_object(name, **kwargs):
         **implicit_args
     )
 
-    _k8s_object(name = name, **kwargs)
-    _k8s_object(name = name + ".resolve", **kwargs)
+    resolve_args = dict(**kwargs)
+    resolve_args.pop("args")
+
+    _k8s_object(name = name, **resolve_args)
+    _k8s_object(name = name + ".resolve", **resolve_args)
 
     if "cluster" in kwargs or "context" in kwargs:
         _k8s_object_create(

--- a/k8s/objects.bzl
+++ b/k8s/objects.bzl
@@ -100,3 +100,4 @@ def k8s_objects(name, objects, **kwargs):
     _run_all(name = name + ".delete", objects = _cmd_objects(".delete", objects, True), **kwargs)
     _run_all(name = name + ".replace", objects = _cmd_objects(".replace", objects), **kwargs)
     _run_all(name = name + ".apply", objects = _cmd_objects(".apply", objects), **kwargs)
+    _run_all(name = name + ".diff", objects = _cmd_objects(".diff", objects), **kwargs)


### PR DESCRIPTION
Previously #410

This adds a `.diff` target to `k8s_object`. In order to avoid pushing when resolving for the purposes of the diff, this also adds a no_push flag to the resolver.

Fixes #242 
