### PR TITLE
Allow overriding the stamp inputs

### DIFF
--- a/k8s/object.bzl
+++ b/k8s/object.bzl
@@ -286,11 +286,11 @@ _common_attrs = {
         executable = True,
         allow_files = True,
     ),
+    # Extra arguments to pass to the resolver.
+    "resolver_args": attr.string_list(),
     # Custom stamp input files. Default to stable-status.txt and volatile-status.txt
     # emitted by the workspace_status command.
     "stamp_srcs": attr.label_list(),
-    # Extra arguments to pass to the resolver.
-    "resolver_args": attr.string_list(),
     "user": attr.string(),
     "_stamper": attr.label(
         default = Label("//k8s:stamper"),

--- a/k8s/object.bzl
+++ b/k8s/object.bzl
@@ -101,9 +101,10 @@ def _impl(ctx):
 
     # Add workspace_status_command files to the args that are pushed to the resolver and adds the
     # files to the runfiles so they are available to the resolver executable.
-    stamp_inputs = [ctx.info_file, ctx.version_file]
-    stamp_args = " ".join(["--stamp-info-file=%s" % _runfiles(ctx, f) for f in stamp_inputs])
-    all_inputs.extend(stamp_inputs)
+    #stamp_inputs = [ctx.info_file, ctx.version_file]
+    #stamp_args = " ".join(["--stamp-info-file=%s" % _runfiles(ctx, f) for f in stamp_inputs])
+    #all_inputs.extend(stamp_inputs)
+    stamp_args = ""
 
     image_chroot_arg = ctx.attr.image_chroot
     image_chroot_arg = ctx.expand_make_variables("image_chroot", image_chroot_arg, {})
@@ -152,9 +153,10 @@ def _impl(ctx):
     ]
 
 def _resolve(ctx, string, output):
-    stamps = [ctx.info_file, ctx.version_file]
+    #stamps = [ctx.info_file, ctx.version_file]
+    stamps = []
     args = ctx.actions.args()
-    args.add_all(stamps, format_each = "--stamp-info-file=%s")
+    #args.add_all(stamps, format_each = "--stamp-info-file=%s")
     args.add(string, format = "--format=%s")
     args.add(output, format = "--output=%s")
     ctx.actions.run(


### PR DESCRIPTION
PR to address https://github.com/bazelbuild/rules_k8s/issues/536

Retain the current behaviour of depending on volatile-status.txt and stable-status.txt, but allow a user to override the stamp inputs.