### PR TITLE
Make the kubectl toolchain type public

### DIFF
--- a/toolchains/kubectl/BUILD
+++ b/toolchains/kubectl/BUILD
@@ -19,7 +19,10 @@ package(default_visibility = ["//visibility:private"])
 licenses(["notice"])  # Apache 2.0
 
 # kubectl toolchain type
-toolchain_type(name = "toolchain_type")
+toolchain_type(
+    name = "toolchain_type",
+    visibility = ["//visibility:public"],
+)
 
 # Default kubectl toolchain that expects the 'kubectl' executable
 # to be in the PATH


### PR DESCRIPTION
Closes https://github.com/bazelbuild/rules_k8s/issues/530.

This allows defining your own kubectl toolchains; e.g.

```
# //:BUILD
toolchain(
    name = "my_kubectl_toolchain",
    target_compatible_with = ...,
    toolchain = "//my/local:kubectl",
    toolchain_type = "@io_bazel_rules_k8s//toolchains/kubectl:toolchain_type",
)
```

```
# WORKSPACE
...

load("@io_bazel_rules_k8s//k8s:k8s.bzl", "k8s_repositories")

k8s_repositories()

load("@io_bazel_rules_k8s//k8s:k8s_go_deps.bzl", k8s_go_deps = "deps")

k8s_go_deps()

register_toolchains(
    "//:my_kubectl_toolchain",
)
```

which then allows more flexibility over what `kubectl_configure` currently allows.