### PR TITLE
fix gazelle

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -30,3 +30,6 @@ gazelle(
 
 # Make Gazelle ignore Go files in the examples directory used in e2e tests.
 # gazelle:exclude examples
+
+# rules_docker's BUILD files follow the go_default_library naming convention
+# gazelle:go_naming_convention_external go_default_library

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -17,6 +17,9 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 load("//k8s:k8s.bzl", "k8s_defaults", "k8s_repositories")
 
+# Tell Gazelle to use @io_bazel_rules_docker as the external repository for rules_docker go packages
+# gazelle:repository go_repository name=io_bazel_rules_docker importpath=github.com/bazelbuild/rules_docker
+
 k8s_repositories()
 
 load("@io_bazel_rules_docker//repositories:repositories.bzl", _rules_docker_repos = "repositories")

--- a/k8s/go/cmd/resolver/BUILD
+++ b/k8s/go/cmd/resolver/BUILD
@@ -19,7 +19,7 @@ package(default_visibility = ["//visibility:private"])
 licenses(["notice"])  # Apache 2.0
 
 go_library(
-    name = "go_default_library",
+    name = "resolver_lib",
     srcs = ["resolver.go"],
     importpath = "github.com/bazelbuild/rules_k8s/k8s/go/cmd/resolver",
     visibility = ["//visibility:private"],
@@ -35,13 +35,13 @@ go_library(
 
 go_binary(
     name = "resolver",
-    embed = [":go_default_library"],
+    embed = [":resolver_lib"],
     visibility = ["//visibility:public"],
 )
 
 go_test(
-    name = "go_default_test",
+    name = "resolver_test",
     srcs = ["resolver_test.go"],
-    embed = [":go_default_library"],
+    embed = [":resolver_lib"],
     deps = ["@com_github_google_go_cmp//cmp:go_default_library"],
 )


### PR DESCRIPTION
Executing `bazel run //:gazelle` on master breaks the build due to changes introduced by `go_naming_convention` and due to the fact that the name of the `io_bazel_rules_docker` repository rule does not match what gazelle would generate based on the importpath. This PR should allow someone to run gazelle on this repository with breaking things.