### PR TITLE
Support k8s_release in kubectl_configure

### DIFF
--- a/toolchains/kubectl/defaults.bzl
+++ b/toolchains/kubectl/defaults.bzl
@@ -24,15 +24,15 @@ k8s_org = "kubernetes"
 # The kubernetes repository.
 k8s_repo = "kubernetes"
 
-# The release commit/tag to for the kubernetes repo.
-k8s_commit = "v1.13.0-beta.1"
+# The release for the kubernetes repo.
+k8s_release = "v1.13.0-beta.1"
 
 # The archive prefix. This is the name of the top level directory in the
 # downloaded repository archive tarball.
-k8s_prefix = "kubernetes-1.13.0-beta.1"
+k8s_prefix = "kubernetes"
 
-# The SHA256 of the k8s repo.
-k8s_sha256 = "dfb39ce36284c1ce228954ca12bf016c09be61e40a875e8af4fff84e116bd3a7"
+# The SHA256 of the k8s release.
+k8s_sha256 = "90edefe1bb5925492579dc77191c8d039b040fa76bd62c93313f0c92082b7031"
 
 # The kubernetes repository infrastructure tools repository.
 # https://github.com/kubernetes/repo-infra

--- a/toolchains/kubectl/kubectl_configure.bzl
+++ b/toolchains/kubectl/kubectl_configure.bzl
@@ -163,6 +163,8 @@ def kubectl_configure(name, **kwargs):
                 kwargs,
             )
 
+            k8s_release = kwargs.get("k8s_release", _k8s_release)
+
             k8s_url = "https://github.com/{}/{}/releases/download/{}/{}.tar.gz".format(
                 _k8s_org,
                 _k8s_repo,


### PR DESCRIPTION
Also default to using k8s_release when not specified

We've been running into an issue daily when depending on 1.18.8, as for some reason GitHub archives are randomly changing the number of characters used as part of an internal generated file, I assume because of some different short_sha config on the servers they have generating these. This also seems to be not totally uncommon for them to change the archive creation process https://github.com/spack/spack/issues/5411 so depending on an actual release is better.

Unfortunately kubernetes/repo-infra doesn't include a source tarball in their releases so we can't add `k8s_repo_infra_release`

```diff
--- kubernetes-9f2892aab98fe339f3bd70e3c470144299398ace/staging/src/k8s.io/component-base/version/base.go       2020-08-13 09:03:25.000000000 -0700
+++ kubernetes-9f2892aab98fe339f3bd70e3c470144299398ace-github-archive/staging/src/k8s.io/component-base/version/base.go        2020-08-13 09:03:25.000000000 -0700
@@ -55,7 +55,7 @@
        // NOTE: The $Format strings are replaced during 'git archive' thanks to the
        // companion .gitattributes file containing 'export-subst' in this same
        // directory.  See also https://git-scm.com/docs/gitattributes
-       gitVersion   = "v0.0.0-master+9f2892aab98"
+       gitVersion   = "v0.0.0-master+9f2892aab98fe3"
        gitCommit    = "9f2892aab98fe339f3bd70e3c470144299398ace" // sha1 from git, output of $(git rev-parse HEAD)
        gitTreeState = ""            // state of git tree, either "clean" or "dirty"
```

