### PR TITLE
Windows compatibility changes

### DIFF
--- a/k8s/apply.sh.tpl
+++ b/k8s/apply.sh.tpl
@@ -16,14 +16,14 @@
 set -euo pipefail
 
 function guess_runfiles() {
-    if [ -d ${BASH_SOURCE[0]}.runfiles ]; then
-        # Runfiles are adjacent to the current script.
-        echo "$( cd ${BASH_SOURCE[0]}.runfiles && pwd )"
-    else
-        # The current script is within some other script's runfiles.
-        mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-        echo $mydir | sed -e 's|\(.*\.runfiles\)/.*|\1|'
-    fi
+    RUNFILE_DIRS=( "${BASH_SOURCE[0]}.runfiles" "${BASH_SOURCE[0]}.exe.runfiles" "$(dirname "${BASH_SOURCE[0]}")" )
+    for candidate_dir in "${RUNFILE_DIRS[@]}"; do
+        if [ -d "$candidate_dir" ]; then
+            pushd "$candidate_dir" > /dev/null 2>&1
+            pwd
+            popd > /dev/null 2>&1
+        fi
+    done
 }
 
 function exe() { echo "\$ ${@/eval/}" ; "$@" ; }

--- a/k8s/create.sh.tpl
+++ b/k8s/create.sh.tpl
@@ -16,14 +16,14 @@
 set -euo pipefail
 
 function guess_runfiles() {
-    if [ -d ${BASH_SOURCE[0]}.runfiles ]; then
-        # Runfiles are adjacent to the current script.
-        echo "$( cd ${BASH_SOURCE[0]}.runfiles && pwd )"
-    else
-        # The current script is within some other script's runfiles.
-        mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-        echo $mydir | sed -e 's|\(.*\.runfiles\)/.*|\1|'
-    fi
+    RUNFILE_DIRS=( "${BASH_SOURCE[0]}.runfiles" "${BASH_SOURCE[0]}.exe.runfiles" "$(dirname "${BASH_SOURCE[0]}")" )
+    for candidate_dir in "${RUNFILE_DIRS[@]}"; do
+        if [ -d "$candidate_dir" ]; then
+            pushd "$candidate_dir" > /dev/null 2>&1
+            pwd
+            popd > /dev/null 2>&1
+        fi
+    done
 }
 
 function exe() { echo "\$ ${@/eval/}" ; "$@" ; }

--- a/k8s/delete.sh.tpl
+++ b/k8s/delete.sh.tpl
@@ -16,14 +16,14 @@
 set -euo pipefail
 
 function guess_runfiles() {
-    if [ -d ${BASH_SOURCE[0]}.runfiles ]; then
-        # Runfiles are adjacent to the current script.
-        echo "$( cd ${BASH_SOURCE[0]}.runfiles && pwd )"
-    else
-        # The current script is within some other script's runfiles.
-        mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-        echo $mydir | sed -e 's|\(.*\.runfiles\)/.*|\1|'
-    fi
+    RUNFILE_DIRS=( "${BASH_SOURCE[0]}.runfiles" "${BASH_SOURCE[0]}.exe.runfiles" "$(dirname "${BASH_SOURCE[0]}")" )
+    for candidate_dir in "${RUNFILE_DIRS[@]}"; do
+        if [ -d "$candidate_dir" ]; then
+            pushd "$candidate_dir" > /dev/null 2>&1
+            pwd
+            popd > /dev/null 2>&1
+        fi
+    done
 }
 
 function exe() { echo "\$ ${@/eval/}" ; "$@" ; }

--- a/k8s/describe.sh.tpl
+++ b/k8s/describe.sh.tpl
@@ -16,14 +16,14 @@
 set -euo pipefail
 
 function guess_runfiles() {
-    if [ -d ${BASH_SOURCE[0]}.runfiles ]; then
-        # Runfiles are adjacent to the current script.
-        echo "$( cd ${BASH_SOURCE[0]}.runfiles && pwd )"
-    else
-        # The current script is within some other script's runfiles.
-        mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-        echo $mydir | sed -e 's|\(.*\.runfiles\)/.*|\1|'
-    fi
+    RUNFILE_DIRS=( "${BASH_SOURCE[0]}.runfiles" "${BASH_SOURCE[0]}.exe.runfiles" "$(dirname "${BASH_SOURCE[0]}")" )
+    for candidate_dir in "${RUNFILE_DIRS[@]}"; do
+        if [ -d "$candidate_dir" ]; then
+            pushd "$candidate_dir" > /dev/null 2>&1
+            pwd
+            popd > /dev/null 2>&1
+        fi
+    done
 }
 
 function exe() { echo "\$ ${@/eval/}" ; "$@" ; }

--- a/k8s/diff.sh.tpl
+++ b/k8s/diff.sh.tpl
@@ -16,14 +16,14 @@
 set -euo pipefail
 
 function guess_runfiles() {
-    if [ -d ${BASH_SOURCE[0]}.runfiles ]; then
-        # Runfiles are adjacent to the current script.
-        echo "$( cd ${BASH_SOURCE[0]}.runfiles && pwd )"
-    else
-        # The current script is within some other script's runfiles.
-        mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-        echo $mydir | sed -e 's|\(.*\.runfiles\)/.*|\1|'
-    fi
+    RUNFILE_DIRS=( "${BASH_SOURCE[0]}.runfiles" "${BASH_SOURCE[0]}.exe.runfiles" "$(dirname "${BASH_SOURCE[0]}")" )
+    for candidate_dir in "${RUNFILE_DIRS[@]}"; do
+        if [ -d "$candidate_dir" ]; then
+            pushd "$candidate_dir" > /dev/null 2>&1
+            pwd
+            popd > /dev/null 2>&1
+        fi
+    done
 }
 
 function exe() { echo "\$ ${@/eval/}" ; "$@" ; }

--- a/k8s/object.bzl
+++ b/k8s/object.bzl
@@ -147,8 +147,8 @@ def _impl(ctx):
         DefaultInfo(
             runfiles = ctx.runfiles(
                 files = [
-                            ctx.executable.resolver,
-                        ] + all_inputs,
+                    ctx.executable.resolver,
+                ] + all_inputs,
                 transitive_files = ctx.attr.resolver[DefaultInfo].default_runfiles.files,
             ),
         ),
@@ -474,8 +474,8 @@ def _implicit_args_as_dict(**kwargs):
 
     return implicit_args
 
-def _sh_wrapper(f, name,  **kwargs):
-    f(name="{}.script".format(name), **kwargs)
+def _sh_wrapper(f, name, **kwargs):
+    f(name = "{}.script".format(name), **kwargs)
     native.sh_binary(name = name, srcs = ["{}.script.sh".format(name)], data = [":{}.script".format(name)])
 
 def k8s_object(name, **kwargs):
@@ -516,32 +516,37 @@ def k8s_object(name, **kwargs):
     if "args" in resolve_args:
         resolve_args.pop("args")
 
-    _sh_wrapper(_k8s_object, name=name, **resolve_args)
-    _sh_wrapper(_k8s_object, name=name + ".resolve", **resolve_args)
+    _sh_wrapper(_k8s_object, name = name, **resolve_args)
+    _sh_wrapper(_k8s_object, name = name + ".resolve", **resolve_args)
 
     if "cluster" in kwargs or "context" in kwargs:
-        _sh_wrapper(_k8s_object_create,
+        _sh_wrapper(
+            _k8s_object_create,
             name = name + ".create",
             resolved = name,
             **common_args
         )
-        _sh_wrapper(_k8s_object_delete,
+        _sh_wrapper(
+            _k8s_object_delete,
             name = name + ".delete",
             resolved = name,
             **common_args
         )
-        _sh_wrapper(_k8s_object_replace,
+        _sh_wrapper(
+            _k8s_object_replace,
             name = name + ".replace",
             resolved = name,
             **common_args
         )
-        _sh_wrapper(_k8s_object_apply,
+        _sh_wrapper(
+            _k8s_object_apply,
             name = name + ".apply",
             resolved = name,
             **common_args
         )
 
-        _sh_wrapper(_k8s_object_diff,
+        _sh_wrapper(
+            _k8s_object_diff,
             name = name + ".diff",
             resolved = name,
             kind = kwargs.get("kind"),
@@ -555,7 +560,8 @@ def k8s_object(name, **kwargs):
         )
 
         if "kind" in kwargs:
-            _sh_wrapper(_k8s_object_describe,
+            _sh_wrapper(
+                _k8s_object_describe,
                 name = name + ".describe",
                 unresolved = kwargs.get("template"),
                 **common_args

--- a/k8s/object.bzl
+++ b/k8s/object.bzl
@@ -476,7 +476,7 @@ def _implicit_args_as_dict(**kwargs):
 
 def _sh_wrapper(f, name, **kwargs):
     f(name = "{}.script".format(name), **kwargs)
-    native.sh_binary(name = name, srcs = ["{}.script.sh".format(name)], data = [":{}.script".format(name)])
+    native.sh_binary(name = name, srcs = ["{}.script.sh".format(name)], data = [":{}.script".format(name)], **_implicit_args_as_dict(**kwargs))
 
 def k8s_object(name, **kwargs):
     """Interact with a K8s object.

--- a/k8s/objects.bzl
+++ b/k8s/objects.bzl
@@ -30,7 +30,7 @@ def _run_all_impl(ctx):
                 for exe in ctx.attr.objects
             ]),
         },
-        output = ctx.outputs.executable,
+        output = ctx.outputs.script,
     )
 
     runfiles = [obj.files_to_run.executable for obj in ctx.attr.objects]
@@ -43,7 +43,7 @@ def _run_all_impl(ctx):
         ),
     ]
 
-_run_all = rule(
+_run_all_script = rule(
     attrs = {
         "delimiter": attr.string(default = ""),
         "objects": attr.label_list(
@@ -54,9 +54,13 @@ _run_all = rule(
             allow_single_file = True,
         ),
     },
-    executable = True,
+    outputs = {"script": "%{name}.sh"},
     implementation = _run_all_impl,
 )
+
+def _run_all(name, **kwargs):
+    _run_all_script(name="{}.script".format(name), **kwargs)
+    native.sh_binary(name = name, srcs = ["{}.script.sh".format(name)], data = [":{}.script".format(name)])
 
 def _reverse(lis, reverse = False):
     """Returns a reversed list if if reverse is true

--- a/k8s/objects.bzl
+++ b/k8s/objects.bzl
@@ -59,7 +59,7 @@ _run_all_script = rule(
 )
 
 def _run_all(name, **kwargs):
-    _run_all_script(name="{}.script".format(name), **kwargs)
+    _run_all_script(name = "{}.script".format(name), **kwargs)
     native.sh_binary(name = name, srcs = ["{}.script.sh".format(name)], data = [":{}.script".format(name)])
 
 def _reverse(lis, reverse = False):

--- a/k8s/replace.sh.tpl
+++ b/k8s/replace.sh.tpl
@@ -16,14 +16,14 @@
 set -euo pipefail
 
 function guess_runfiles() {
-    if [ -d ${BASH_SOURCE[0]}.runfiles ]; then
-        # Runfiles are adjacent to the current script.
-        echo "$( cd ${BASH_SOURCE[0]}.runfiles && pwd )"
-    else
-        # The current script is within some other script's runfiles.
-        mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-        echo $mydir | sed -e 's|\(.*\.runfiles\)/.*|\1|'
-    fi
+    RUNFILE_DIRS=( "${BASH_SOURCE[0]}.runfiles" "${BASH_SOURCE[0]}.exe.runfiles" "$(dirname "${BASH_SOURCE[0]}")" )
+    for candidate_dir in "${RUNFILE_DIRS[@]}"; do
+        if [ -d "$candidate_dir" ]; then
+            pushd "$candidate_dir" > /dev/null 2>&1
+            pwd
+            popd > /dev/null 2>&1
+        fi
+    done
 }
 
 function exe() { echo "\$ ${@/eval/}" ; "$@" ; }

--- a/k8s/resolve-all.sh.tpl
+++ b/k8s/resolve-all.sh.tpl
@@ -16,14 +16,14 @@
 set -euo pipefail
 
 function guess_runfiles() {
-    if [ -d ${BASH_SOURCE[0]}.runfiles ]; then
-        # Runfiles are adjacent to the current script.
-        echo "$( cd ${BASH_SOURCE[0]}.runfiles && pwd )"
-    else
-        # The current script is within some other script's runfiles.
-        mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-        echo $mydir | sed -e 's|\(.*\.runfiles\)/.*|\1|'
-    fi
+    RUNFILE_DIRS=( "${BASH_SOURCE[0]}.runfiles" "${BASH_SOURCE[0]}.exe.runfiles" "$(dirname "${BASH_SOURCE[0]}")" )
+    for candidate_dir in "${RUNFILE_DIRS[@]}"; do
+        if [ -d "$candidate_dir" ]; then
+            pushd "$candidate_dir" > /dev/null 2>&1
+            pwd
+            popd > /dev/null 2>&1
+        fi
+    done
 }
 
 RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"

--- a/k8s/resolve.sh.tpl
+++ b/k8s/resolve.sh.tpl
@@ -16,14 +16,14 @@
 set -euo pipefail
 
 function guess_runfiles() {
-    if [ -d ${BASH_SOURCE[0]}.runfiles ]; then
-        # Runfiles are adjacent to the current script.
-        echo "$( cd ${BASH_SOURCE[0]}.runfiles && pwd )"
-    else
-        # The current script is within some other script's runfiles.
-        mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-        echo $mydir | sed -e 's|\(.*\.runfiles\)/.*|\1|'
-    fi
+    RUNFILE_DIRS=( "${BASH_SOURCE[0]}.runfiles" "${BASH_SOURCE[0]}.exe.runfiles" "$(dirname "${BASH_SOURCE[0]}")" )
+    for candidate_dir in "${RUNFILE_DIRS[@]}"; do
+        if [ -d "$candidate_dir" ]; then
+            pushd "$candidate_dir" > /dev/null 2>&1
+            pwd
+            popd > /dev/null 2>&1
+        fi
+    done
 }
 
 RUNFILES="${PYTHON_RUNFILES:-$(guess_runfiles)}"


### PR DESCRIPTION
This set of changes adds windows compatibility.
The current code is not windows compatible because it directly uses executable bash scripts, which doesn't work on windows (it expects executables).

The fix is not overly difficult, and simply requires us to add sh_binary wrappers to the scripts and to adjust the guess_runfiles functions accordingly.