### PR TITLE
Updated rules_docker to fix CI

### DIFF
--- a/k8s/k8s.bzl
+++ b/k8s/k8s.bzl
@@ -88,11 +88,11 @@ def k8s_repositories():
     maybe(
         http_archive,
         name = "io_bazel_rules_docker",
-        sha256 = "f4a39a410da7e497a7ccd19e28c69c93a851d6adb76798355a0c8ba9855e9b75",
-        strip_prefix = "rules_docker-e15c9ebf203b7fa708e69ff5f1cdcf427d7edf6f",
-        # `master` as of 2021-02-04
+        sha256 = "efda18e39a63ee3c1b187b1349f61c48c31322bf84227d319b5dece994380bb6",
+        strip_prefix = "rules_docker-f929d80c5a4363994968248d87a892b1c2ef61d4",
+        # `master` as of 2021-04-25
         urls = [
-            "https://github.com/bazelbuild/rules_docker/archive/e15c9ebf203b7fa708e69ff5f1cdcf427d7edf6f.zip",
+            "https://github.com/bazelbuild/rules_docker/archive/f929d80c5a4363994968248d87a892b1c2ef61d4.tar.gz",
         ],
     )
 


### PR DESCRIPTION
This addresses the following build error
```
(00:31:21) ERROR: An error occurred during the fetch of repository 'com_github_google_go_containerregistry':
   java.io.IOException: Error downloading [https://api.github.com/repos/google/go-containerregistry/tarball/8a2841911ffee4f6892ca0083e89752fb46c48dd] to /var/lib/buildkite-agent/.cache/bazel/_bazel_buildkite-agent/ec321eb2cc2d0f8f91b676b6d4c66c29/external/com_github_google_go_containerregistry/8a2841911ffee4f6892ca0083e89752fb46c48dd.tar.gz: Checksum was cadb09cb5bcbe00688c73d716d1c9e774d6e4959abec4c425a1b995faf33e964 but wanted 60b9a600affa5667bd444019a4e218b7752d8500cfa923c1ac54ce2f88f773e2
(00:31:21) ERROR: /workdir/k8s/go/cmd/resolver/BUILD:21:1: //k8s/go/cmd/resolver:go_default_library depends on @com_github_google_go_containerregistry//pkg/authn:go_default_library in repository @com_github_google_go_containerregistry which failed to fetch. no such package '@com_github_google_go_containerregistry//pkg/authn': java.io.IOException: Error downloading [https://api.github.com/repos/google/go-containerregistry/tarball/8a2841911ffee4f6892ca0083e89752fb46c48dd] to /var/lib/buildkite-agent/.cache/bazel/_bazel_buildkite-agent/ec321eb2cc2d0f8f91b676b6d4c66c29/external/com_github_google_go_containerregistry/8a2841911ffee4f6892ca0083e89752fb46c48dd.tar.gz: Checksum was cadb09cb5bcbe00688c73d716d1c9e774d6e4959abec4c425a1b995faf33e964 but wanted 60b9a600affa5667bd444019a4e218b7752d8500cfa923c1ac54ce2f88f773e2
(00:31:22) ERROR: Analysis of target '//k8s/go/cmd/resolver:resolver' failed; build aborted: no such package '@com_github_google_go_containerregistry//pkg/authn': java.io.IOException: Error downloading [https://api.github.com/repos/google/go-containerregistry/tarball/8a2841911ffee4f6892ca0083e89752fb46c48dd] to /var/lib/buildkite-agent/.cache/bazel/_bazel_buildkite-agent/ec321eb2cc2d0f8f91b676b6d4c66c29/external/com_github_google_go_containerregistry/8a2841911ffee4f6892ca0083e89752fb46c48dd.tar.gz: Checksum was cadb09cb5bcbe00688c73d716d1c9e774d6e4959abec4c425a1b995faf33e964 but wanted 60b9a600affa5667bd444019a4e218b7752d8500cfa923c1ac54ce2f88f773e2
```