### PR TITLE
Drop support for ubuntu 16

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -45,7 +45,7 @@ platforms:
   min_supported_version:
     name: "Minimum Supported Version"
     bazel: "2.2.0"
-    platform: ubuntu1604
+    platform: ubuntu1804
     build_targets:
     - "--"
     - "..."


### PR DESCRIPTION
Recent versions of pyyaml do not support ubuntu 16 (which has past its lifetime support window)