### PR TITLE
Update rules_docker to v0.20.0

### DIFF
--- a/k8s/go/pkg/resolver/resolver.go
+++ b/k8s/go/pkg/resolver/resolver.go
@@ -228,7 +228,8 @@ func (r *Resolver) publishSingle(spec imageSpec, stamper *compat.Stamper) (strin
 	if err != nil {
 		return "", fmt.Errorf("unable to determine parts of the image from the specified arguments: %v", err)
 	}
-	img, err := compat.ReadImage(imgParts)
+	cr := compat.Reader{Parts: imgParts}
+	img, err := cr.ReadImage()
 	if err != nil {
 		return "", fmt.Errorf("error reading image: %v", err)
 	}

--- a/k8s/k8s.bzl
+++ b/k8s/k8s.bzl
@@ -89,12 +89,9 @@ def k8s_repositories():
     maybe(
         http_archive,
         name = "io_bazel_rules_docker",
-        sha256 = "efda18e39a63ee3c1b187b1349f61c48c31322bf84227d319b5dece994380bb6",
-        strip_prefix = "rules_docker-f929d80c5a4363994968248d87a892b1c2ef61d4",
-        # `master` as of 2021-04-25
-        urls = [
-            "https://github.com/bazelbuild/rules_docker/archive/f929d80c5a4363994968248d87a892b1c2ef61d4.tar.gz",
-        ],
+        sha256 = "92779d3445e7bdc79b961030b996cb0c91820ade7ffa7edca69273f404b085d5",
+        strip_prefix = "rules_docker-0.20.0",
+        urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.20.0/rules_docker-v0.20.0.tar.gz"],
     )
 
     maybe(


### PR DESCRIPTION
New version of rules_docker was release, and it has a change that breaks rules_k8s.