### PR TITLE
Enable wrapping k8s_objects diff exit codes

### DIFF
--- a/k8s/objects.bzl
+++ b/k8s/objects.bzl
@@ -22,13 +22,23 @@ def _runfiles(ctx, f):
     return "PYTHON_RUNFILES=${RUNFILES} ${RUNFILES}/%s $@" % _get_runfile_path(ctx, f)
 
 def _run_all_impl(ctx):
+    if ctx.attr.wrap_exits:
+        _prefix = "code=0"
+        _append = " || code=1"
+        _suffix = "exit $code"
+    else:
+        _prefix = ""
+        _append = ""
+        _suffix = ""
+
+    _statements = ("\n" + ctx.attr.delimiter).join([_prefix] +
+                                                   [_runfiles(ctx, exe.files_to_run.executable) + _append for exe in ctx.attr.objects] +
+                                                   [_suffix])
+
     ctx.actions.expand_template(
         template = ctx.file._template,
         substitutions = {
-            "%{resolve_statements}": ("\n" + ctx.attr.delimiter).join([
-                _runfiles(ctx, exe.files_to_run.executable)
-                for exe in ctx.attr.objects
-            ]),
+            "%{resolve_statements}": _statements,
         },
         output = ctx.outputs.executable,
     )
@@ -49,6 +59,7 @@ _run_all = rule(
         "objects": attr.label_list(
             cfg = "target",
         ),
+        "wrap_exits": attr.bool(default = False),
         "_template": attr.label(
             default = Label("//k8s:resolve-all.sh.tpl"),
             allow_single_file = True,
@@ -100,4 +111,4 @@ def k8s_objects(name, objects, **kwargs):
     _run_all(name = name + ".delete", objects = _cmd_objects(".delete", objects, True), **kwargs)
     _run_all(name = name + ".replace", objects = _cmd_objects(".replace", objects), **kwargs)
     _run_all(name = name + ".apply", objects = _cmd_objects(".apply", objects), **kwargs)
-    _run_all(name = name + ".diff", objects = _cmd_objects(".diff", objects), **kwargs)
+    _run_all(name = name + ".diff", objects = _cmd_objects(".diff", objects), wrap_exits = True, **kwargs)


### PR DESCRIPTION
Fixes: https://github.com/bazelbuild/rules_k8s/issues/679

This diff proposes one strategy we could take to wrapping the command execution of the kubectl diffs in order to address the above issue.