### PR TITLE
Fix the checksum of the pyyaml external repository

### DIFF
--- a/k8s/k8s.bzl
+++ b/k8s/k8s.bzl
@@ -51,7 +51,7 @@ def k8s_repositories():
         http_archive,
         name = "com_github_yaml_pyyaml",
         build_file_content = _com_github_yaml_pyyaml_build_file,
-        sha256 = "e9df8412ddabc9c21b4437ee138875b95ebb32c25f07f962439e16005152e00e",
+        sha256 = "ba59d7e97eb131d8f8f52d19cb124bb67772f4c7f4d14cb2919deb885ef8c572",
         strip_prefix = "pyyaml-5.1.2",
         urls = ["https://github.com/yaml/pyyaml/archive/5.1.2.zip"],
     )


### PR DESCRIPTION
It appears that for some reason, the zip file hosted at https://github.com/yaml/pyyaml/archive/5.1.2.zip has changed. This has caused our CI to fail when trying to build. Specifically I noticed that `k8s.delete` targets fail with the following message:

```
Error downloading [https://github.com/yaml/pyyaml/archive/5.1.2.zip] to /private/var/tmp/_bazel_ronilichtman/89a39ba59b237e88128981215b79d884/external/com_github_yaml_pyyaml/temp6627556357927520273/5.1.2.zip: Checksum was ba59d7e97eb131d8f8f52d19cb124bb67772f4c7f4d14cb2919deb885ef8c572 but wanted e9df8412ddabc9c21b4437ee138875b95ebb32c25f07f962439e16005152e00e
```

Looking at the difference between the zip from the local repository cache on my mac and the one currently hosted in GitHub I see a diff on the zip "modified time" headers:

`pyyaml` from GitHub (today), mismatched sha256:

```
➜  Downloads xxd pyyaml-5.1.2.zip | head
00000000: 504b 0304 0a00 0000 0000 af0a ff4e 0000  PK...........N..
```

`pyyaml` from my local mac cache, matching sha256:

```
➜  e9df8412ddabc9c21b4437ee138875b95ebb32c25f07f962439e16005152e00e xxd file| head
00000000: 504b 0304 0a00 0000 0000 af92 fe4e 0000  PK...........N..
```

Note the difference at offset 12 (`af0a ff4e`) vs (`af92 fe4e`).