### PR TITLE
Added toolchain support for Apple M1 and made toolchain_type public to allow extensions

### DIFF
--- a/k8s/k8s.bzl
+++ b/k8s/k8s.bzl
@@ -62,7 +62,8 @@ def k8s_repositories():
         "@io_bazel_rules_k8s//toolchains/kubectl:kubectl_linux_amd64_toolchain",
         "@io_bazel_rules_k8s//toolchains/kubectl:kubectl_linux_arm64_toolchain",
         "@io_bazel_rules_k8s//toolchains/kubectl:kubectl_linux_s390x_toolchain",
-        "@io_bazel_rules_k8s//toolchains/kubectl:kubectl_osx_toolchain",
+        "@io_bazel_rules_k8s//toolchains/kubectl:kubectl_macos_x86_64_toolchain",
+        "@io_bazel_rules_k8s//toolchains/kubectl:kubectl_macos_arm64_toolchain",
         "@io_bazel_rules_k8s//toolchains/kubectl:kubectl_windows_toolchain",
     )
 

--- a/toolchains/kubectl/BUILD
+++ b/toolchains/kubectl/BUILD
@@ -14,7 +14,7 @@
 
 load(":kubectl_toolchain.bzl", "kubectl_toolchain")
 
-package(default_visibility = ["//visibility:private"])
+package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
@@ -63,10 +63,25 @@ toolchain(
 )
 
 toolchain(
-    name = "kubectl_osx_toolchain",
+    name = "kubectl_macos_x86_64_toolchain",
     target_compatible_with = [
-        "@platforms//os:osx",
+        "@platforms//os:macos",
         "@platforms//cpu:x86_64",
+    ],
+    toolchain = "@k8s_config//:toolchain",
+    toolchain_type = ":toolchain_type",
+)
+
+alias(
+    name = "kubectl_osx_toolchain",
+    actual = ":kubectl_macos_x86_64_toolchain",
+)
+
+toolchain(
+    name = "kubectl_macos_arm64_toolchain",
+    target_compatible_with = [
+        "@platforms//os:macos",
+        "@platforms//cpu:arm64",
     ],
     toolchain = "@k8s_config//:toolchain",
     toolchain_type = ":toolchain_type",


### PR DESCRIPTION
1. Added and registered `kubectl_macos_arm64_toolchain`
2. Changed the name of `kubectl_osx_toolchain` to `kubectl_macos_x86_64_toolchain` and added an alias for backwards compatibility. Also updated the registration.
3. Made `toolchain/kubectl` package `public` to allow for extensions for this toolchain_type

#696 